### PR TITLE
Use protonup-ng package

### DIFF
--- a/overlay/opt/scripts/install_protonup.sh
+++ b/overlay/opt/scripts/install_protonup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###
-# File: install_lutris.sh
+# File: install_protonup.sh
 # Project: scripts
 # File Created: Thursday, 1st January 1970 12:45:00 pm
 # Author: Console and webGui login account (jsunnex@gmail.com)
@@ -9,7 +9,7 @@
 # Modified By: Console and webGui login account (jsunnex@gmail.com)
 ###
 
-pkg=protonup
+pkg=protonup-ng
 script_path=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd );
 script_name=$( basename "${BASH_SOURCE[0]}" )
 


### PR DESCRIPTION
Looks like vanilla protonup is far out of date with the new Proton naming scheme, see https://github.com/AUNaseef/protonup/issues/25 . When I run it instead I get errors about permissioning and missing files. There is a forked version called protonup-ng that fixes this issue.