### PR TITLE
Note the default games path in compose file

### DIFF
--- a/docs/compose-files/docker-compose.default.yml
+++ b/docs/compose-files/docker-compose.default.yml
@@ -31,6 +31,8 @@ services:
       # The location of your home directory.
       - /opt/container-data/steam-headless/home/:/home/default/:rw
       # The location where all games should be installed.
+      # This path needs to be set as a library path in Steam after logging in.
+      # Otherwise, Steam will store games in the home directory above.
       - /mnt/games/:/mnt/games/:rw
       # Input devices used for mouse and joypad support inside the container.
       - /dev/input/:/dev/input/:ro


### PR DESCRIPTION
I was confused why games weren't showing up in my bind mount. This is documented elsewhere, but not in the compose file.