### PR TITLE
Update Sunshine to 0.20.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -435,18 +435,19 @@ RUN \
     echo
 
 # Install sunshine
-ARG SUNSHINE_VERSION=0.11.1
+ARG SUNSHINE_VERSION=0.20.0
 RUN \
     echo "**** Fetch Sunshine deb package ****" \
         && cd /tmp \
         && wget -O /tmp/sunshine-debian.deb \
-            https://github.com/loki-47-6F-64/sunshine/releases/download/v${SUNSHINE_VERSION}/sunshine-debian.deb \
+            https://github.com/LizardByte/sunshine/releases/download/v${SUNSHINE_VERSION}/sunshine-debian-bullseye-amd64.deb \
     && \
     echo "**** Update apt database ****" \
         && apt-get update \
     && \
     echo "**** Install Sunshine ****" \
         && apt-get install -y /tmp/sunshine-debian.deb \
+        && apt-get install -y libboost-chrono1.74.0 \
     && \
     echo "**** Section cleanup ****" \
         && apt-get clean autoclean -y \


### PR DESCRIPTION
[Sunshine 0.18.0 has drastically improved CPU performance](https://github.com/LizardByte/Sunshine/releases/tag/v0.18.0): With Sunshine 0,11, the maximum resolution that I was able to stream was 720p. With Sunshine 0.20.0, I can easily stream 1080p and probably more.

Also, a dependency on libboost-chrono-1.74.0 has been added, but hasn't been declared correctly in the .deb package.