### PR TITLE
Display the progress of desktop app installation before starting the desktop

### DIFF
--- a/overlay/opt/scripts/install_firefox.sh
+++ b/overlay/opt/scripts/install_firefox.sh
@@ -4,7 +4,7 @@ echo "**** Installing/upgrading Firefox via flatpak ****"
 
 # Install Firefox
 flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo 
-flatpak --user install --assumeyes --noninteractive --or-update flathub org.mozilla.firefox
+flatpak --user install --assumeyes --or-update flathub org.mozilla.firefox
 
 # Configure Firefox as the default browser
 echo "Configure Firefox..."

--- a/overlay/opt/scripts/install_protonup.sh
+++ b/overlay/opt/scripts/install_protonup.sh
@@ -4,7 +4,7 @@ echo "**** Installing/upgrading ProtonUp-Qt via flatpak ****"
 
 # Install ProtonUp-Qt
 flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo 
-flatpak --user install --assumeyes --noninteractive --or-update net.davidotek.pupgui2
+flatpak --user install --assumeyes --or-update net.davidotek.pupgui2
 
 # Configure Firefox as the default browser
 echo "Configure ProtonUp-Qt..."

--- a/overlay/opt/scripts/install_steam.sh
+++ b/overlay/opt/scripts/install_steam.sh
@@ -4,7 +4,7 @@ echo "**** Installing/upgrading Steam via flatpak ****"
 
 # Install Steam client
 flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo 
-flatpak --user install --assumeyes --noninteractive --or-update flathub com.valvesoftware.Steam
+flatpak --user install --assumeyes --or-update flathub com.valvesoftware.Steam
 # Configure any required overrides
 flatpak --user override --filesystem=/mnt/games com.valvesoftware.Steam
 # TODO: Check if we should add /dev/dri here??

--- a/overlay/usr/bin/start-desktop.sh
+++ b/overlay/usr/bin/start-desktop.sh
@@ -5,7 +5,7 @@
 # File Created: Thursday, 1st January 1970 12:00:00 pm
 # Author: Console and webGui login account (jsunnex@gmail.com)
 # -----
-# Last Modified: Saturday, 8th July 2023 2:34:11 am
+# Last Modified: Saturday, 8th July 2023 3:52:39 pm
 # Modified By: Console and webGui login account (jsunnex@gmail.com)
 ###
 set -e
@@ -23,15 +23,18 @@ export $(dbus-launch)
 
 
 # EXECUTE PROCESS:
-# Install/Upgrade user apps
-if [[ ! -f /tmp/.desktop-apps-updated.lock ]]; then
-    source /opt/scripts/install_steam.sh
-    source /opt/scripts/install_firefox.sh
-    source /opt/scripts/install_protonup.sh
-    touch /tmp/.desktop-apps-updated.lock
-fi
 # Wait for the X server to start
 wait_for_x
+# Install/Upgrade user apps
+if [[ ! -f /tmp/.desktop-apps-updated.lock ]]; then
+    xterm -geometry 200x50+0+0 -ls -e /bin/bash -c "
+        source /opt/scripts/install_steam.sh;
+        source /opt/scripts/install_firefox.sh;
+        source /opt/scripts/install_protonup.sh;
+        sleep 1;
+    "
+    touch /tmp/.desktop-apps-updated.lock
+fi
 # Run the desktop environment
 echo "**** Starting Xfce4 ****"
 /usr/bin/startxfce4 &


### PR DESCRIPTION
This just prevents people from seeing a black screen for a long time and assuming something is going wrong. This initial setup is installaing flatpaks to the mounted home directory. This will not need to happen on every container startup. So this black screen is only a problem on the first start. But this change at least gives people something to look at.