### PR TITLE
Add: core package in arch for emudeck

### DIFF
--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -69,6 +69,7 @@ RUN \
             vim \
             wget \
             xz \
+            zenity \
     && \
     echo "**** Install python ****" \
 	    && pacman -Syu --noconfirm --needed \
@@ -200,6 +201,21 @@ RUN \
 # Install audio requirements
 RUN \
     echo "**** Install X Server requirements ****" \
+	    && pacman -Syu --noconfirm --needed \
+            alsa-utils \
+            pavucontrol \
+            pulseaudio \
+            pulseaudio-alsa \
+    && \
+    echo "**** Section cleanup ****" \
+	    && pacman -Scc --noconfirm \
+        && rm -fr /var/lib/pacman/sync/* \
+    && \
+    echo
+
+# Install emulation dependencies for EmuDeck
+RUN \
+    echo "**** Install EmuDeck requirements ****" \
 	    && pacman -Syu --noconfirm --needed \
             alsa-utils \
             pavucontrol \

--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -49,6 +49,7 @@ RUN \
             docbook-xml \
             docbook-xsl \
             fakeroot \
+            fuse \
             git \
             jq \
             less \


### PR DESCRIPTION
Since steam OS is making Linux more mainstream there are more people who want to have ready made installers for emulation and such.

EmuDeck is the most popular of these installer and just needed one (edit: two) core package to be installed for it to work in arch.

please note I have not tried this in debian yet, this is just a small fix for the arch build