### PR TITLE
Update sunshine.conf

### DIFF
--- a/overlay/templates/sunshine/sunshine.conf
+++ b/overlay/templates/sunshine/sunshine.conf
@@ -180,7 +180,7 @@ file_apps = /home/default/sunshine/apps.json
 # Increasing the value slightly reduces encoding efficiency, but the tradeoff is usually
 # worth it to gain the use of more CPU cores for encoding. The ideal value is the lowest
 # value that can reliably encode at your desired streaming settings on your hardware.
-# min_threads = 1
+min_threads = 6
 
 # Allows the client to request HEVC Main or HEVC Main10 video streams.
 # HEVC is more CPU-intensive to encode, so enabling this may reduce performance when using software encoding.


### PR DESCRIPTION
To get proper performance @1440p and up sunshine thread must be at least =6

Tested on a AMD Ryzen 3700X + AMD Vega 64