### PR TITLE
If ENABLE_STEAM supervised; enable after desktop is loaded

### DIFF
--- a/overlay/etc/cont-init.d/90-configure_steam.sh
+++ b/overlay/etc/cont-init.d/90-configure_steam.sh
@@ -2,8 +2,8 @@
 echo "**** Configure Steam ****"
 
 if [ "${ENABLE_STEAM:-}" = "true" ]; then
-    echo "Enable Steam service"
-    sed -i 's|^autostart.*=.*$|autostart=true|' /etc/supervisor.d/steam.ini
+    # echo "Enable Steam service"
+    # sed -i 's|^autostart.*=.*$|autostart=true|' /etc/supervisor.d/steam.ini
     # Remove old autostart script. We should be starting steam with the supervisor service
     mkdir -p "${USER_HOME:?}/.config/autostart"
     # if grep "Exec=/usr/bin/flatpak" "${USER_HOME:?}/.config/autostart/Steam.desktop" &> /dev/null; then

--- a/overlay/usr/bin/start-desktop.sh
+++ b/overlay/usr/bin/start-desktop.sh
@@ -35,11 +35,16 @@ if [[ ! -f /tmp/.desktop-apps-updated.lock ]]; then
     "
     touch /tmp/.desktop-apps-updated.lock
 fi
+
 # Run the desktop environment
 echo "**** Starting Xfce4 ****"
 /usr/bin/startxfce4 &
 desktop_pid=$!
 
+if [ "${ENABLE_STEAM:-}" = "true" ]; then
+    echo "Start Steam service"
+    sudo supervisorctl start steam
+fi
 
 # WAIT FOR CHILD PROCESS:
 wait "$desktop_pid"


### PR DESCRIPTION
Only made this change because one user on discord was getting an race condition error that sometimes prevented him from accessing the desktop..  Feel free to discard ;)