### PR TITLE
Bump Sunshine & Move vaapi related stuff to 60-configure-gpu

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -410,25 +410,25 @@ RUN \
     echo
 
 # Setup video streaming deps
-RUN \
-    echo "**** Update apt database ****" \
-        && apt-get update \
-    && \
-    echo "**** Install Intel media drivers and VAAPI ****" \
-        && apt-get install -y --no-install-recommends \
-            intel-media-va-driver-non-free \
-            i965-va-driver-shaders \
-            libva2 \
-    && \
-    echo "**** Section cleanup ****" \
-        && apt-get clean autoclean -y \
-        && apt-get autoremove -y \
-        && rm -rf \
-            /var/lib/apt/lists/* \
-            /var/tmp/* \
-            /tmp/* \
-    && \
-    echo
+#RUN \
+#    echo "**** Update apt database ****" \
+#        && apt-get update \
+#    && \
+#    echo "**** Install Intel media drivers and VAAPI ****" \
+#        && apt-get install -y --no-install-recommends \
+#            intel-media-va-driver-non-free \
+#            i965-va-driver-shaders \
+#            libva2 \
+#    && \
+#    echo "**** Section cleanup ****" \
+#        && apt-get clean autoclean -y \
+#        && apt-get autoremove -y \
+#        && rm -rf \
+#            /var/lib/apt/lists/* \
+#            /var/tmp/* \
+#            /tmp/* \
+#    && \
+#    echo
 
 # Install tools for monitoring hardware
 RUN \
@@ -453,7 +453,7 @@ RUN \
     echo
 
 # Install Sunshine
-COPY --from=lizardbyte/sunshine:1303def-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
+COPY --from=lizardbyte/sunshine:v0.21.0-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
 RUN \
     echo "**** Update apt database ****" \
         && apt-get update \

--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -172,6 +172,7 @@ function install_amd_gpu_driver {
             lib32-vulkan-radeon \
             vulkan-icd-loader \
             vulkan-radeon \
+            vdpau-driver-all \
             libva-mesa-driver
     elif command -v apt-get &> /dev/null; then
         install_deb_mesa

--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -157,6 +157,7 @@ function install_deb_mesa {
             mesa-utils \
             mesa-utils-extra \
             vulkan-tools \
+            libva2 \
             &>> /tmp/init-mesa-libs-install.log
     else
         print_step_header "Mesa has already been installed into this container"
@@ -170,7 +171,8 @@ function install_amd_gpu_driver {
             lib32-vulkan-icd-loader \
             lib32-vulkan-radeon \
             vulkan-icd-loader \
-            vulkan-radeon
+            vulkan-radeon \
+            libva-mesa-driver
     elif command -v apt-get &> /dev/null; then
         install_deb_mesa
     fi
@@ -183,7 +185,9 @@ function install_intel_gpu_driver {
             lib32-vulkan-icd-loader \
             lib32-vulkan-intel \
             vulkan-icd-loader \
-            vulkan-intel
+            vulkan-intel \
+            intel-media-va-driver-non-free \
+            i965-va-driver-shaders
     elif command -v apt-get &> /dev/null; then
         install_deb_mesa
     fi


### PR DESCRIPTION
Discard if not wanted or a better way, seems to work for now. Can be used for refrence and i will close the PR later. 

Tested with integrated amd graphics 780m for moonlight streaming. 
Untested intel accelerated encoding!

Followed steps from debian wiki with the addition of libva-mesa-driver which i don't think is needed, but included to keep inline with SID.

Note: without --runtime=nvidia the container would still show two cards. I had to specify /dev/dri/renderD129 in sunshine to get vaapi working as renderD128 (the default) was the nvidia card oddly enough.