### PR TITLE
quirk for gnome software not displaying apps

### DIFF
--- a/overlay/etc/cont-init.d/99-quirks.sh
+++ b/overlay/etc/cont-init.d/99-quirks.sh
@@ -1,0 +1,3 @@
+if command -v apt-get &> /dev/null; then
+    apt-get --reinstall install -y gnome-software-plugin-flatpak
+fi


### PR DESCRIPTION
Discard if there is a better way, but i've found this makes the software store work every time for now.