### PR TITLE
Make SID repo optional

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -543,7 +543,8 @@ ENV \
     STEAM_ARGS="-silent" \
     ENABLE_SUNSHINE="true" \
     ENABLE_EVDEV_INPUTS="true" \
-    ENABLE_WOL_POWER_MANAGER="false"
+    ENABLE_WOL_POWER_MANAGER="false" \
+    ENABLE_SID="false"
 
 # Configure required ports
 ENV \

--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -144,8 +144,10 @@ function install_deb_mesa {
     if [ ! -f /tmp/init-mesa-libs-install.log ]; then
         print_step_header "Enable i386 arch"
         dpkg --add-architecture i386
-        print_step_header "Add Debian SID sources"
-        echo "deb http://deb.debian.org/debian/ sid main" > /etc/apt/sources.list
+	if [ "${ENABLE_SID:-}" = "true" ]; then
+            print_step_header "Add Debian SID sources"
+            echo "deb http://deb.debian.org/debian/ sid main" > /etc/apt/sources.list
+	fi
         apt-get update &>> /tmp/init-mesa-libs-install.log
         print_step_header "Install mesa vulkan drivers"
         echo "" >> /tmp/init-mesa-libs-install.log


### PR DESCRIPTION
Set the default to false as it allows for full hardware encoding and AMD compat,
If set to true some tweaks are needed but unsure exactly what, adding libva2 libva2:i386 from sid isn't enough it would seem.