### PR TITLE
Add fallback to GitHub for NVIDIA driver downloads

### DIFF
--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -38,8 +38,18 @@ function download_driver {
         wget -q --show-progress --progress=bar:force:noscroll \
             -O /tmp/NVIDIA.run \
             "http://download.nvidia.com/XFree86/Linux-x86_64/${nvidia_host_driver_version:?}/NVIDIA-Linux-x86_64-${nvidia_host_driver_version:?}.run"
-        [[ $? -gt 0 ]] && print_error "Unable to download driver. Exit!" && return 1
-
+        if [[ $? -gt 0 ]]; then
+            print_error "Unable to download driver from NVIDIA. Trying GitHub..."
+            # Strip the 'v' from the version if present (v545.23.08 -> 545.23.08)
+            local stripped_version="${nvidia_host_driver_version#v}"
+            wget -q --show-progress --progress=bar:force:noscroll \
+                -O /tmp/NVIDIA.run \
+                "https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-aarch64-${stripped_version}.run"
+            if [[ $? -gt 0 ]]; then
+                print_error "Unable to download driver from GitHub. Exit!"
+                return 1
+            fi
+        fi
         mv /tmp/NVIDIA.run "${USER_HOME:?}/Downloads/NVIDIA_${nvidia_host_driver_version:?}.run"
     fi
 }


### PR DESCRIPTION
An issue opened https://github.com/Steam-Headless/docker-steam-headless/issues/152, specifically in TrueNas Scale where 4 versions are not available in the repository https://download.nvidia.com/XFree86/Linux-x86_64, (`545.23.08`, `555.42.06`, `545.23.08` and `555.42.06`) However, the saving grace is that these versions are required for GPU acceleration for Flatpaks.

> Thank you. I’m primarily facing issues because flatpak only has a package for .06, so all flatpak apps are no longer GPU accelerated as a result.

From: https://forums.developer.nvidia.com/t/545-23-08-is-not-listed-in-the-nvidia-driver-downloads-page/273181/3

To Solve this, FlatHub has created a NVIDIA Driver repository where these obscure version's `.run` files are available to download. https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/

The Entire process can be found in my Solution post: https://github.com/Steam-Headless/docker-steam-headless/issues/152#issuecomment-2208788858

This pull request first attempts to download the driver from the NVIDIA repository and then falls back to the Flathub repository while printing an error if it is unable to download the driver.