### PR TITLE
remove libva-vdpau

### DIFF
--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -360,7 +360,6 @@ RUN \
             libva \
             libva-mesa-driver \
             libva-intel-driver \
-            libva-vdpau-driver \
     && \
     echo "**** Section cleanup ****" \
 	    && pacman -Scc --noconfirm \


### PR DESCRIPTION
Just to clean up the github actions log, still not recommended to use