### PR TITLE
Another stable update for sunshine

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -465,7 +465,7 @@ RUN \
     echo
 
 # Install Sunshine
-COPY --from=lizardbyte/sunshine:v2025.118.151840-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
+COPY --from=lizardbyte/sunshine:v2025.122.141614-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
 RUN \
     echo "**** Update apt database ****" \
         && apt-get update \


### PR DESCRIPTION
not really needed as we arn't using the flatpak version i guess:

build(linux)!: remove legacy input option 
fix(flatpak): fix broken desktop file, icons, and service
fix(web-ui): fix new version notification conditions
chore(l10n): update translations