### PR TITLE
Fix Sunshine input devices and VNC audio streaming on Arch image

### DIFF
--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -249,7 +249,7 @@ RUN \
             gnome-software \
     && \
     echo "**** Configure flatpak ****" \
-        && chmod u-s /usr/bin/bwrap \
+        && chmod u+s /usr/bin/bwrap \
         && flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo \
         && su - default -c "flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo" \
     && \
@@ -326,6 +326,7 @@ RUN \
             gst-plugins-base \
             gst-plugins-good \
             gst-plugins-ugly \
+            socat \
     && \
     #echo "**** Fetch ucspi-tcp ****" \
     #    && mkdir -p /tmp/ucspi-tcp-0.88 \
@@ -387,11 +388,12 @@ RUN \
 # Install Sunshine
 RUN \
     echo "**** Install stable sunshine ****" \
-        && su - default -c "yay -Syu --noconfirm --needed miniupnpc sunshine-bin" \
+        && su - default -c "yay -Syu --noconfirm --needed icu76 miniupnpc sunshine-bin" \
         && setcap cap_sys_admin+p $(readlink -f $(which sunshine)) \
+        && ln -sf /usr/lib/libicuuc.so /usr/lib/libicuuc.so.76 \
     && \
     echo "**** Section cleanup ****" \
-	    && pacman -Scc --noconfirm \
+        && pacman -Scc --noconfirm \
         && rm -fr /home/default/.cache/yay \
         && rm -fr /var/lib/pacman/sync/* \
         && rm -fr /var/cache/pacman/pkg/* \
@@ -417,6 +419,8 @@ RUN \
     echo "**** Install Steam ****" \
 	    && pacman -Syu --noconfirm --needed \
             steam \
+        && mkdir -p /usr/games \
+        && ln -sf /usr/bin/steam /usr/games/steam \
     && \
     echo "**** Section cleanup ****" \
 	    && pacman -Scc --noconfirm \
@@ -487,6 +491,7 @@ ENV \
 # APPIMAGE_EXTRACT_AND_RUN="0" 
 ENV \
     MODE="primary" \
+    SKIP_UDEV_WAIT="1" \
     WEB_UI_MODE="vnc" \
     ENABLE_VNC_AUDIO="true" \
     NEKO_PASSWORD=neko \

--- a/overlay/etc/cont-init.d/30-configure_udev.sh
+++ b/overlay/etc/cont-init.d/30-configure_udev.sh
@@ -4,14 +4,14 @@ print_header "Configure udevd"
 
 # Since this container may also be run with CAP_SYS_ADMIN, ensure we can actually execute "udevadm trigger"
 run_dumb_udev="false"
+# Ensure udev runtime path exists so udevd/libudev consumers (Xorg, sunshine) can see input devices
+if [ ! -d /run/udev ]; then
+    print_step_header "Create /run/udev path"
+    mkdir -p /run/udev
+fi
 if [ ! -w /sys ]; then
     # Disable supervisord script since we are not able to write to sysfs
     print_step_header "Disable udevd - /sys is mounted RO"
-    sed -i 's|^autostart.*=.*$|autostart=false|' /etc/supervisor.d/udev.ini
-    run_dumb_udev="true"
-elif [ ! -d /run/udev ]; then
-    # Disable supervisord script since we are not able to write to udev/data path
-    print_step_header "Disable udevd - /run/udev does not exist"
     sed -i 's|^autostart.*=.*$|autostart=false|' /etc/supervisor.d/udev.ini
     run_dumb_udev="true"
 elif [ ! -w /run/udev ]; then

--- a/overlay/etc/supervisor.d/vnc-audio.ini
+++ b/overlay/etc/supervisor.d/vnc-audio.ini
@@ -4,7 +4,7 @@ priority=30
 autostart=false
 autorestart=true
 user=%(ENV_USER)s
-command=tcpserver 127.0.0.1 %(ENV_PORT_AUDIO_STREAM)s gst-launch-1.0 -q pulsesrc server=%(ENV_PULSE_SOCKET_DIR)s/pulse-socket ! audio/x-raw, channels=2, rate=24000 ! cutter ! opusenc ! webmmux ! fdsink fd=1
+command=/usr/local/bin/audiostream.sh
 stopsignal=INT
 stdout_logfile=/home/%(ENV_USER)s/.cache/log/audiostream.log
 stdout_logfile_maxbytes=10MB

--- a/overlay/usr/bin/start-desktop.sh
+++ b/overlay/usr/bin/start-desktop.sh
@@ -30,6 +30,20 @@ export XDG_CACHE_HOME="${USER_HOME:?}/.cache"
 export XDG_CONFIG_HOME="${USER_HOME:?}/.config"
 export XDG_DATA_HOME="${USER_HOME:?}/.local/share"
 
+# Ensure Steam bootstrap link points to the actual data directory
+STEAM_DATA_DIR="${USER_HOME}/.local/share/Steam"
+STEAM_LINK="${USER_HOME}/.steam/steam"
+if [ -d "$STEAM_LINK" ] && [ ! -L "$STEAM_LINK" ]; then
+    mkdir -p "${STEAM_DATA_DIR}" "${STEAM_LINK%/*}"
+    shopt -s dotglob
+    for item in "${STEAM_LINK}"/*; do
+        mv -n "$item" "${STEAM_DATA_DIR}/" 2> /dev/null || true
+    done
+    shopt -u dotglob
+    rm -rf "$STEAM_LINK"
+fi
+ln -sfn "${STEAM_DATA_DIR}" "${STEAM_LINK}"
+
 # EXECUTE PROCESS:
 # Wait for the X server to start
 wait_for_x

--- a/overlay/usr/bin/start-dumb-udev.sh
+++ b/overlay/usr/bin/start-dumb-udev.sh
@@ -18,8 +18,8 @@ trap _term SIGTERM SIGINT
 
 
 # EXECUTE PROCESS:
-# Start dumb-udev
-dumb-udev &
+# Start dumb-udev in relay-only mode to avoid chmod on read-only /dev mounts
+dumb-udev --relay-only &
 dumb_udev_pid=$!
 
 # WAIT FOR CHILD PROCESS:

--- a/overlay/usr/bin/start-sunshine.sh
+++ b/overlay/usr/bin/start-sunshine.sh
@@ -70,6 +70,9 @@ export_desktop_dbus_session
 # Wait for the desktop to start
 wait_for_desktop
 
+# Prefer ICU 76 for sunshine binary
+export LD_PRELOAD="/usr/lib/libicuuc.so.76:/usr/lib/libicui18n.so.76:/usr/lib/libicudata.so.76${LD_PRELOAD:+:$LD_PRELOAD}"
+
 # Start the sunshine server
 /usr/bin/dumb-init /usr/bin/sunshine "${USER_HOME:?}/.config/sunshine/sunshine.conf" &
 sunshine_pid=$!

--- a/overlay/usr/bin/start-xorg.sh
+++ b/overlay/usr/bin/start-xorg.sh
@@ -20,7 +20,7 @@ trap _term SIGTERM SIGINT
 
 # EXECUTE PROCESS:
 # Wait for udev
-if [ $(grep autostart /etc/supervisor.d/udev.ini 2> /dev/null) == "autostart=true" ]; then
+if [ $(grep autostart /etc/supervisor.d/udev.ini 2> /dev/null) == "autostart=true" ] && [ "${SKIP_UDEV_WAIT:-0}" != "1" ]; then
     wait_for_udev
 fi
 # Run X server

--- a/overlay/usr/local/bin/audiostream.sh
+++ b/overlay/usr/local/bin/audiostream.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+# Simple TCP audio forwarder for VNC audio channel
+PORT="${PORT_AUDIO_STREAM:-32037}"
+socket="${PULSE_SOCKET_DIR:-/tmp/pulse}/pulse-socket"
+gst_cmd="gst-launch-1.0 -q pulsesrc server=${socket} ! audio/x-raw,channels=2,rate=24000 ! cutter ! opusenc ! webmmux ! fdsink fd=1"
+exec socat TCP-LISTEN:${PORT},fork,reuseaddr "EXEC:${gst_cmd}"


### PR DESCRIPTION
Ensure udev runtime path exists in init to keep real udev running so Sunshine/Xorg see virtual input devices.
Keep dumb-udev in relay-only mode and retain ICU 76 preload for Sunshine startup.
Add dedicated VNC audio forwarder script using socat + gstreamer and point supervisor to it.
Minor desktop/Xorg launcher tweaks to align with the above.
Dockerfile retains required deps (socat, icu76) to support the fixes.