### PR TITLE
Fix Sunshine input devices in restricted containers

### DIFF
--- a/docs/compose-files/.env
+++ b/docs/compose-files/.env
@@ -99,6 +99,9 @@ SUNSHINE_PASS=admin
 ##      Available Options:  ['true', 'false']
 ##      Description:        Enable Keyboard and Mouse Passthrough. This will configure the Xorg server to catch all
 ##                          evdev events for Keyboard, Mouse, etc.
+##                          In restricted container runtimes that use a private /dev (for example Docker-in-LXC),
+##                          virtual Sunshine input devices may require the fallback udev path to materialize
+##                          /dev/input/event* nodes before Xorg can attach them.
 ##      Supported Modes:    ['primary']
 ENABLE_EVDEV_INPUTS=true
 ## FORCE_X11_DUMMY_CONFIG:

--- a/overlay/usr/bin/start-dumb-udev.sh
+++ b/overlay/usr/bin/start-dumb-udev.sh
@@ -10,17 +10,85 @@
 ###
 set -e
 
+state_dir=/run/udev-input-fix
+
 # CATCH TERM SIGNAL:
 _term() {
-    kill -TERM "$dumb_udev_pid" 2>/dev/null
+    kill -TERM "${sync_pid:-}" 2>/dev/null
+    kill -TERM "${dumb_udev_pid:-}" 2>/dev/null
+    kill -TERM "${udevd_pid:-}" 2>/dev/null
 }
 trap _term SIGTERM SIGINT
 
+sync_input_nodes() {
+    mkdir -p /dev/input
+
+    for sys in /sys/class/input/*/dev; do
+        [[ -f "${sys}" ]] || continue
+
+        node=$(basename "$(dirname "${sys}")")
+        path="/dev/input/${node}"
+        [[ -e "${path}" ]] && continue
+
+        IFS=: read -r major minor < "${sys}"
+        mknod "${path}" c "${major}" "${minor}" 2>/dev/null || continue
+        chmod 0660 "${path}" 2>/dev/null || true
+        chgrp input "${path}" 2>/dev/null || true
+    done
+}
+
+sunshine_inputs_present() {
+    for name_file in /sys/class/input/*/device/name; do
+        [[ -f "${name_file}" ]] || continue
+        case "$(cat "${name_file}" 2>/dev/null || true)" in
+            *passthrough*|Sunshine*)
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
 
 # EXECUTE PROCESS:
-# Start dumb-udev
+# If a real udev daemon can be started in this restricted environment, prefer
+# that over dumb-udev. This gives us /run/udev/control and keeps the existing
+# Xorg startup ordering intact, even when /sys is mounted read-only.
+mkdir -p "${state_dir}"
+if command -v udevd &>/dev/null; then
+    unshare --net udevd --daemon &>/dev/null || true
+else
+    unshare --net /lib/systemd/systemd-udevd --daemon &>/dev/null || true
+fi
+
+if pgrep -x systemd-udevd >/dev/null 2>&1; then
+    udevd_pid=$(pgrep -xo systemd-udevd || true)
+fi
+
 dumb-udev &
 dumb_udev_pid=$!
+
+while true; do
+    sync_input_nodes
+
+    if sunshine_inputs_present; then
+        if [[ ! -e "${state_dir}/xorg-restarted" ]]; then
+            # Sunshine creates its virtual input devices on client connect. In
+            # restricted containers with a private /dev, the sysfs devices may
+            # exist before /dev/input/event* nodes are visible to Xorg. Build
+            # the missing nodes, then restart Xorg once so it enumerates them
+            # cleanly.
+            sleep 2
+            sync_input_nodes
+            supervisorctl restart xorg >/dev/null 2>&1 || true
+            : > "${state_dir}/xorg-restarted"
+        fi
+    else
+        rm -f "${state_dir}/xorg-restarted"
+    fi
+
+    sleep 1
+done &
+sync_pid=$!
 
 # WAIT FOR CHILD PROCESS:
 wait "$dumb_udev_pid"


### PR DESCRIPTION
## Summary

This adjusts the fallback `dumb-udev` path for restricted container environments where:

- `/sys` is read-only or otherwise prevents the normal `udev` path
- `/dev` is a private tmpfs inside the container
- Sunshine virtual input devices appear in sysfs, but the matching `/dev/input/event*` nodes are not materialized for Xorg

In that state, Moonlight video works but keyboard/mouse input can fail because Xorg sees the hotplug event before usable device nodes exist.

This change makes the fallback path:

- try to start a real `systemd-udevd` if available
- materialize missing `/dev/input/*` nodes from `/sys/class/input/*/dev`
- restart Xorg once when Sunshine virtual input devices appear so they are enumerated cleanly

It also adds a short note to the compose env docs for `ENABLE_EVDEV_INPUTS`.

## Why

This was reproduced and debugged live on a running Proxmox Docker-in-LXC deployment. In that environment:

- `Mouse passthrough` / `Keyboard passthrough` existed in `/proc/bus/input/devices`
- Xorg initially failed with `Unable to open evdev device ".../eventXX" (No such file or directory)`
- once the missing `/dev/input/event*` nodes were created and Xorg re-enumerated, the devices attached successfully and input started working

Related: fixes/extends the scenario discussed in #107.

## Validation

- `bash -n overlay/usr/bin/start-dumb-udev.sh`
- live-tested behavior on the Proxmox LXC deployment described above
