### PR TITLE
fix: rename DISPLAY to X_DISPLAY to avoid name override from the host's X11 config

### DIFF
--- a/docs/compose-files/.env
+++ b/docs/compose-files/.env
@@ -8,7 +8,7 @@
 NAME=SteamHeadless
 TZ=Pacific/Auckland
 USER_LOCALES=en_US.UTF-8 UTF-8
-DISPLAY=:55
+X_DISPLAY=:55
 SHM_SIZE=2G
 ## HOME_DIR:
 ##      Description:    The path to the home directory on your host. Mounts to `/home/default` inside the container.

--- a/docs/compose-files/docker-compose.amd+intel.privileged.yml
+++ b/docs/compose-files/docker-compose.amd+intel.privileged.yml
@@ -28,7 +28,7 @@ services:
       # System
       - TZ=${TZ}
       - USER_LOCALES=${USER_LOCALES}
-      - DISPLAY=${DISPLAY}
+      - DISPLAY=${X_DISPLAY}
       # User
       - PUID=${PUID}
       - PGID=${PGID}

--- a/docs/compose-files/docker-compose.amd+intel.yml
+++ b/docs/compose-files/docker-compose.amd+intel.yml
@@ -33,7 +33,7 @@ services:
       # System
       - TZ=${TZ}
       - USER_LOCALES=${USER_LOCALES}
-      - DISPLAY=${DISPLAY}
+      - DISPLAY=${X_DISPLAY}
       # User
       - PUID=${PUID}
       - PGID=${PGID}

--- a/docs/compose-files/docker-compose.nvidia.privileged.yml
+++ b/docs/compose-files/docker-compose.nvidia.privileged.yml
@@ -31,7 +31,7 @@ services:
       # System
       - TZ=${TZ}
       - USER_LOCALES=${USER_LOCALES}
-      - DISPLAY=${DISPLAY}
+      - DISPLAY=${X_DISPLAY}
       # User
       - PUID=${PUID}
       - PGID=${PGID}

--- a/docs/compose-files/docker-compose.nvidia.yml
+++ b/docs/compose-files/docker-compose.nvidia.yml
@@ -36,7 +36,7 @@ services:
       # System
       - TZ=${TZ}
       - USER_LOCALES=${USER_LOCALES}
-      - DISPLAY=${DISPLAY}
+      - DISPLAY=${X_DISPLAY}
       # User
       - PUID=${PUID}
       - PGID=${PGID}


### PR DESCRIPTION
This pr fixes the problem mentioned in the following issues

- https://github.com/Steam-Headless/docker-steam-headless/issues/224
- https://github.com/Steam-Headless/docker-steam-headless/issues/128