### PR TITLE
Fix high memory consumption caused by /dev/shm orphan files

### DIFF
--- a/overlay/usr/bin/start-dumb-udev.sh
+++ b/overlay/usr/bin/start-dumb-udev.sh
@@ -21,6 +21,7 @@ _term() {
 trap _term SIGTERM SIGINT
 
 sync_input_nodes() {
+    created_nodes=0
     mkdir -p /dev/input
 
     for sys in /sys/class/input/*/dev; do
@@ -34,6 +35,7 @@ sync_input_nodes() {
         mknod "${path}" c "${major}" "${minor}" 2>/dev/null || continue
         chmod 0660 "${path}" 2>/dev/null || true
         chgrp input "${path}" 2>/dev/null || true
+        created_nodes=1
     done
 }
 
@@ -70,20 +72,19 @@ dumb_udev_pid=$!
 while true; do
     sync_input_nodes
 
-    if sunshine_inputs_present; then
-        if [[ ! -e "${state_dir}/xorg-restarted" ]]; then
-            # Sunshine creates its virtual input devices on client connect. In
-            # restricted containers with a private /dev, the sysfs devices may
-            # exist before /dev/input/event* nodes are visible to Xorg. Build
-            # the missing nodes, then restart Xorg once so it enumerates them
-            # cleanly.
-            sleep 2
-            sync_input_nodes
-            supervisorctl restart xorg >/dev/null 2>&1 || true
-            : > "${state_dir}/xorg-restarted"
-        fi
-    else
-        rm -f "${state_dir}/xorg-restarted"
+    if sunshine_inputs_present \
+        && [[ "${created_nodes}" -eq 1 ]] \
+        && [[ ! -e "${state_dir}/xorg-restarted" ]]; then
+        # Sunshine creates its virtual input devices on client connect. In
+        # restricted containers with a private /dev, the sysfs devices may
+        # exist before /dev/input/event* nodes are visible to Xorg. Build
+        # the missing nodes, then restart Xorg once so it enumerates them
+        # cleanly. The sentinel persists for the container lifetime to avoid
+        # restart storms on reconnect cycles.
+        sleep 2
+        sync_input_nodes
+        supervisorctl restart xorg >/dev/null 2>&1 || true
+        : > "${state_dir}/xorg-restarted"
     fi
 
     sleep 1


### PR DESCRIPTION
Hi @Josh5, I hope you're doing well.

First of all, a huge thanks for the Steam Headless project. I'm sharing a GPU between multiple apps on TrueNAS, and Steam Headless allows me to use that GPU for gaming (streaming to my TV) every now and then without needing a dedicated VM or GPU.

Today I noticed that the NAS machine was using too much memory after updating the apps and, while tracing it, I pinpointed that Steam Headless memory usage through `/dev/shm` was high. Even without opening Moonlight, the container had climbed to about 15GB of RAM one time while running in the background.

I'm running the container using Compose in privileged mode. Its contents follow, if it helps to reproduce the scenario.

<details>
<summary>Docker Compose contents</summary>

```yaml
version: '3.8'
services:
  steam-headless:
    cap_add:
      - NET_ADMIN
      - SYS_ADMIN
      - SYS_NICE
      - DAC_READ_SEARCH
    container_name: steam-headless
    deploy:
      resources:
        reservations:
          devices:
            - capabilities:
                - gpu
                - display
                - video
                - compute
                - utility
              count: 1
              driver: nvidia
    device_cgroup_rules:
      - c 13:* rmw
    devices:
      - /dev/fuse
      - /dev/uinput
      - /dev/dri:/dev/dri
    environment:
      - TZ=America/Sao_Paulo
      - USER_LOCALES=en_US.UTF-8 UTF-8
      - DISPLAY=:55
      - PUID=1000
      - PGID=1000
      - UMASK=000
      - USER_PASSWORD=[REDACTED]
      - MODE=primary
      - WEB_UI_MODE=vnc
      - ENABLE_VNC_AUDIO=true
      - PORT_NOVNC_WEB=8083
      - NEKO_NAT1TO1=
      - ENABLE_STEAM=true
      - STEAM_ARGS=-silent
      - ENABLE_SUNSHINE=true
      - SUNSHINE_USER=[REDACTED]
      - SUNSHINE_PASS=[REDACTED]
      - ENABLE_EVDEV_INPUTS=true
      - FORCE_X11_DUMMY_CONFIG=true
      - NVIDIA_DRIVER_CAPABILITIES=all
      - NVIDIA_VISIBLE_DEVICES=all
    extra_hosts:
      - NAS-SH:127.0.0.1
    hostname: NAS-SH
    image: josh5/steam-headless
    ipc: host
    network_mode: host
    privileged: True
    restart: unless-stopped
    runtime: nvidia
    security_opt:
      - seccomp:unconfined
      - apparmor:unconfined
    shm_size: 2G
    ulimits:
      nofile:
        hard: 524288
        soft: 1024
    volumes:
      - /mnt/apps/steam-headless/home:/home/default:rw
      - /mnt/apps/steam-headless/games:/mnt/games:rw
      - /mnt/apps/steam-headless/socket/x11:/tmp/.X11-unix:rw
      - /mnt/apps/steam-headless/socket/pulse:/tmp/pulse:rw 
```
</details>

Digging into the issue, I found that the background loop in `overlay/usr/bin/start-dumb-udev.sh` restarts Xorg every time a Sunshine virtual input device appears and re-arms the sentinel on disconnect. In privileged containers, `udev` already creates the input nodes natively, so the restart isn't necessary.

This PR modifies `start-dumb-udev.sh` in two ways: `sync_input_nodes` now flags when it actually has to `mknod` a missing node, and Xorg is only restarted when a node is truly created. The sentinel is also kept permanent so it fires at most once per container lifetime.

I tested this by leaving the container idle and connecting/disconnecting Moonlight several times, starting a game, playing a bit and then closing it. The `/dev/shm` usage remains stable instead of growing, and Sunshine input passthrough still works as expected in my setup. 

I hope these changes makes sense and doesn't negatively impact functionality in restricted containers. Again, thanks for the project and the time you've invested in it.