### PR TITLE
fix max_map_count to allow higher value than 524288

### DIFF
--- a/overlay/etc/cont-init.d/11-setup_sysctl_values.sh
+++ b/overlay/etc/cont-init.d/11-setup_sysctl_values.sh
@@ -3,7 +3,7 @@
 print_header "Configure some system kernel parameters"
 
 
-if [ "$(cat /proc/sys/vm/max_map_count)" -ge 524288 ]; then
+if [ "$(cat /proc/sys/vm/max_map_count)" -le 524288 ]; then
     if [ -w "/proc/sys/vm/max_map_count" ]; then
         print_step_header "Setting the maximum number of memory map areas a process can create to 524288"
         echo 524288 > /proc/sys/vm/max_map_count


### PR DESCRIPTION
Hello!

I figured out that we cannot go above `524288` for the `max_map_count` parameters.
The script `11-setup_sysctl_values.sh` apply this value at startup if the value system value is higher.
So here is the small fix.