### PR TITLE
Fix race condition in start-dumb-udev.sh causing repeated Xorg restarts

### DIFF
--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -72,6 +72,7 @@ RUN \
             wget \
             xmlstarlet \
             xz \
+            wireguard-tools \
     && \
     echo "**** Install python ****" \
 	    && pacman -Syu --noconfirm --needed \
@@ -495,7 +496,13 @@ ENV \
     STEAM_ARGS="-silent" \
     ENABLE_SUNSHINE="true" \
     ENABLE_EVDEV_INPUTS="true" \
-    ENABLE_WOL_POWER_MANAGER="false" 
+    ENABLE_WOL_POWER_MANAGER="false" \
+    WIREGUARD_ENABLED="false" \
+    WIREGUARD_PORT="51820" \
+    WIREGUARD_ADDRESS="10.13.13.1/24" \
+    WIREGUARD_PRIVATE_KEY="" \
+    WIREGUARD_PEER_PUBLIC_KEY="" \
+    WIREGUARD_PEER_ALLOWED_IPS=""
 
 # Configure required ports
 ENV \
@@ -504,6 +511,7 @@ ENV \
 
 # Expose the required ports
 EXPOSE 8083
+EXPOSE 51820/udp
 
 # Set entrypoint
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -86,6 +86,8 @@ RUN \
             wget \
             xmlstarlet \
             xz-utils \
+            wireguard \
+            wireguard-tools \
     && \
     echo "**** Install python ****" \
         && apt-get install -y --no-install-recommends \
@@ -573,7 +575,13 @@ ENV \
     ENABLE_SUNSHINE="true" \
     ENABLE_EVDEV_INPUTS="true" \
     ENABLE_WOL_POWER_MANAGER="false" \
-    ENABLE_SID="false"
+    ENABLE_SID="false" \
+    WIREGUARD_ENABLED="false" \
+    WIREGUARD_PORT="51820" \
+    WIREGUARD_ADDRESS="10.13.13.1/24" \
+    WIREGUARD_PRIVATE_KEY="" \
+    WIREGUARD_PEER_PUBLIC_KEY="" \
+    WIREGUARD_PEER_ALLOWED_IPS=""
 
 # Configure required ports
 ENV \
@@ -582,6 +590,7 @@ ENV \
 
 # Expose the required ports
 EXPOSE 8083
+EXPOSE 51820/udp
 
 # Set entrypoint
 RUN chmod +x /entrypoint.sh

--- a/overlay/etc/cont-init.d/11-setup_sysctl_values.sh
+++ b/overlay/etc/cont-init.d/11-setup_sysctl_values.sh
@@ -3,7 +3,7 @@
 print_header "Configure some system kernel parameters"
 
 
-if [ "$(cat /proc/sys/vm/max_map_count)" -ge 524288 ]; then
+if [ "$(cat /proc/sys/vm/max_map_count)" -lt 524288 ]; then
     if [ -w "/proc/sys/vm/max_map_count" ]; then
         print_step_header "Setting the maximum number of memory map areas a process can create to 524288"
         echo 524288 > /proc/sys/vm/max_map_count

--- a/overlay/etc/cont-init.d/99-configure_wireguard.sh
+++ b/overlay/etc/cont-init.d/99-configure_wireguard.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -euo pipefail
+umask 077
+
+if [ "${WIREGUARD_ENABLED:-}" != "true" ]; then
+    exit 0
+fi
+
+if ! command -v wg >/dev/null 2>&1; then
+    echo "Error: wg command not found. Please ensure wireguard-tools is installed." >&2
+    exit 1
+fi
+
+# Validate Port
+PORT="${WIREGUARD_PORT:-51820}"
+if ! [[ "$PORT" =~ ^[0-9]+$ ]] || (( 10#$PORT < 1 )) || (( 10#$PORT > 65535 )); then
+    echo "Error: WIREGUARD_PORT must be a valid integer between 1 and 65535. Got: '$PORT'" >&2
+    exit 1
+fi
+
+# Validate Address
+ADDRESS="${WIREGUARD_ADDRESS:-10.13.13.1/24}"
+if ! [[ "$ADDRESS" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}(/[0-9]{1,2})?$ ]]; then
+    echo "Error: WIREGUARD_ADDRESS must be a valid IPv4 address or CIDR (e.g., 10.13.13.1/24). Got: '$ADDRESS'" >&2
+    exit 1
+fi
+
+mkdir -p /etc/wireguard
+
+if [ -n "${WIREGUARD_PRIVATE_KEY:-}" ]; then
+    PRIVATE_KEY="$WIREGUARD_PRIVATE_KEY"
+else
+    PRIVATE_KEY=$(wg genkey)
+    echo "$PRIVATE_KEY" > /etc/wireguard/privatekey
+fi
+
+PUBLIC_KEY=$(echo "$PRIVATE_KEY" | wg pubkey)
+echo "WireGuard Public Key: $PUBLIC_KEY"
+
+cat <<EOF > /etc/wireguard/wg0.conf
+[Interface]
+PrivateKey = $PRIVATE_KEY
+ListenPort = $PORT
+Address = $ADDRESS
+EOF
+
+if [ -n "${WIREGUARD_PEER_PUBLIC_KEYS:-}" ]; then
+    # Strip all whitespace from the input strings to prevent issues with spaces after commas
+    CLEAN_KEYS="${WIREGUARD_PEER_PUBLIC_KEYS//[[:space:]]/}"
+    CLEAN_IPS="${WIREGUARD_PEER_ALLOWED_IPS//[[:space:]]/}"
+
+    IFS=',' read -ra KEYS <<< "$CLEAN_KEYS"
+    IFS=',' read -ra IPS <<< "$CLEAN_IPS"
+
+    if [ "${#KEYS[@]}" -ne "${#IPS[@]}" ]; then
+        echo "Error: The number of WIREGUARD_PEER_PUBLIC_KEYS (${#KEYS[@]}) does not match the number of WIREGUARD_PEER_ALLOWED_IPS (${#IPS[@]})." >&2
+        exit 1
+    fi
+
+    for i in "${!KEYS[@]}"; do
+        if [ -z "${KEYS[$i]}" ] || [ -z "${IPS[$i]}" ]; then
+            echo "Error: Empty peer configuration detected (check for trailing commas or empty entries)." >&2
+            exit 1
+        fi
+        cat <<EOF >> /etc/wireguard/wg0.conf
+[Peer]
+PublicKey = ${KEYS[$i]}
+AllowedIPs = ${IPS[$i]}
+EOF
+    done
+fi
+
+chmod 600 /etc/wireguard/wg0.conf

--- a/overlay/etc/supervisor.d/wireguard.ini
+++ b/overlay/etc/supervisor.d/wireguard.ini
@@ -1,0 +1,7 @@
+[program:wireguard]
+command=bash -c "wg-quick up wg0 && tail -f /dev/null"
+autostart=true
+autorestart=true
+user=root
+stdout_logfile=/var/log/supervisor/wireguard.log
+stderr_logfile=/var/log/supervisor/wireguard.err.log

--- a/overlay/usr/bin/start-dumb-udev.sh
+++ b/overlay/usr/bin/start-dumb-udev.sh
@@ -5,12 +5,16 @@
 # File Created: Tuesday, 12th January 2022 8:46:47 am
 # Author: Josh.5 (jsunnex@gmail.com)
 # -----
-# Last Modified: Friday, 14th January 2022 9:21:00 am
-# Modified By: Josh.5 (jsunnex@gmail.com)
+# Last Modified: Saturday, 20th June 2026 9:21:00 am
+# Modified By: Victor Lavaud (victor.lavaud@pm.me)
 ###
 set -e
 
 state_dir=/run/udev-input-fix
+
+# Number of consecutive seconds the Sunshine/passthrough input devices must
+# be absent before the watcher re-arms itself. Tune via env var if needed.
+ABSENCE_DEBOUNCE_SECONDS="${ABSENCE_DEBOUNCE_SECONDS:-10}"
 
 # CATCH TERM SIGNAL:
 _term() {
@@ -67,10 +71,12 @@ fi
 dumb-udev &
 dumb_udev_pid=$!
 
+absent_seconds=0
 while true; do
     sync_input_nodes
-
     if sunshine_inputs_present; then
+        # Devices are present again - cancel any debounce countdown in progress.
+        absent_seconds=0
         if [[ ! -e "${state_dir}/xorg-restarted" ]]; then
             # Sunshine creates its virtual input devices on client connect. In
             # restricted containers with a private /dev, the sysfs devices may
@@ -83,7 +89,13 @@ while true; do
             : > "${state_dir}/xorg-restarted"
         fi
     else
-        rm -f "${state_dir}/xorg-restarted"
+        if [[ -e "${state_dir}/xorg-restarted" ]]; then
+            absent_seconds=$(( absent_seconds + 1 ))
+            if (( absent_seconds >= ABSENCE_DEBOUNCE_SECONDS )); then
+                rm -f "${state_dir}/xorg-restarted"
+                absent_seconds=0
+            fi
+        fi
     fi
 
     sleep 1


### PR DESCRIPTION
start-dumb-udev.sh restarts Xorg once when it notices a Sunshine virtual input device (or an evdev passthrough device) appear, so Xorg can pick it up. It remembers having done this with a flag file, and only allows itself to restart Xorg again once that device has gone away.

The problem is a race between two things happening on their own timelines: the watcher checks for the device once a second, while Sunshine removes and recreates its virtual devices independently (for example while a client keeps retrying a connection). If the watcher's check happens to land in the brief moment between Sunshine removing the old device and creating the new one, it thinks the device is gone for good and resets its flag. The moment the new device appears a second later, it looks like a brand new device to the watcher, which restarts Xorg again. A flaky client connection can turn this into a continuous Xorg restart loop, taking down the whole desktop session.

The fix: don't trust a single absent check. The watcher now needs to see the device missing for several consecutive seconds before it treats it as actually gone (configurable via ABSENCE_DEBOUNCE_SECONDS, default 10). A quick remove-then-recreate no longer falls inside that window, so it's no longer mistaken for a fresh device needing a fresh restart.