### PR TITLE
Ensure that AMD drivers are installed for AMD APUs

### DIFF
--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -26,7 +26,7 @@ export intel_gpu_model="$(lspci | grep -i "VGA compatible controller: Intel" | c
 
 # AMD params
 export amd_cpu_model="$(lscpu | grep 'Model name:' | grep -i amd | cut -d':' -f2 | xargs)"
-export amd_gpu_model="$(lspci | grep -i vga | grep -i amd)"
+export amd_gpu_model="$(lspci | grep -i -E 'vga|display' | grep -i amd)"
 
 function download_driver {
     local driver_url


### PR DESCRIPTION
I've been troubleshooting trying to get my Strix Halo-based (Ryzen AI Max+ 395) Unraid box to work with this container. I've managed to get it working, but I had to implement this workaround to ensure the Vulkan drivers get installed. AMD APUs show in `lspci` output as a "Display" device, not "VGA".

Additionally, I had to disable hardware accelerated encoding in both Sunshine and Steam in order to get Moonlight and Steam streaming to work. Not sure if this is down to a misconfiguration or missing driver here or there, or just a general lack of software support for the Strix Halo platform.