### PR TITLE
fix: stop a client-requested mode from wedging the NVIDIA display engine

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -113,8 +113,8 @@ jobs:
       if: success() && (startsWith(github.ref, 'refs/heads/') || startsWith(github.ref, 'refs/tags/'))
       uses: docker/login-action@v1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASS }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASS }} 
     
     # Run docker build and push
     - name: Docker Build and Push

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -51,7 +51,7 @@ jobs:
         echo  "FLAVOUR='${FLAVOUR}'"
         echo  "GITHUB_REF='${GITHUB_REF}'"
         echo  "GITHUB_REPOSITORY='${GITHUB_REPOSITORY}'"
-        DOCKER_IMAGE=docker.io/josh5/steam-headless
+        DOCKER_IMAGE=docker.io/bytetrade/steam-headless
         VERSION_TAG=${GITHUB_REF#refs/*/}
         DOCKER_TAGS=""
         if [[ ${VERSION_TAG%/merge} == 'master' ]]; then
@@ -78,7 +78,7 @@ jobs:
         echo "Build: [$(date +"%F %T")] [${GITHUB_REF_NAME}] [${GITHUB_SHA}] [${FLAVOUR}]" > ./overlay/version.txt
 
         DOCKER_PUSH="true"
-        if [[ ${DOCKER_IMAGE} != 'docker.io/josh5/steam-headless' ]]; then
+        if [[ ${DOCKER_IMAGE} != 'docker.io/bytetrade/steam-headless' ]]; then
           DOCKER_PUSH="false"
         fi
         if [[ ${VERSION_TAG%/merge} =~ "pr-"* ]]; then
@@ -114,7 +114,7 @@ jobs:
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        password: ${{ secrets.DOCKER_PASS }}
     
     # Run docker build and push
     - name: Docker Build and Push

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -8,9 +8,6 @@ on:
     tags: [ '**' ]
   pull_request:
     branches: [ staging, master ]
-  schedule:
-    # At 02:30 on Saturday
-    - cron:  '30 2 * * 6'
 
 jobs:
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
               uses: docker/build-push-action@v3
               with:
                   push: true
-                  tags: bytetrade/steam-headless:${{ github.event.inputs.tags }}
+                  tags: beclab/steam-headless:${{ github.event.inputs.tags }}
                   file: Dockerfile.debian
                 #   platforms: linux/amd64,linux/arm64
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
               uses: docker/build-push-action@v3
               with:
                   push: true
-                  tags: bytetrade/steamheadless:${{ github.event.inputs.tags }}
+                  tags: bytetrade/steam-headless:${{ github.event.inputs.tags }}
                   file: Dockerfile.debian
                 #   platforms: linux/amd64,linux/arm64
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+
+
+name: Publish to Dockerhub
+
+on:
+    workflow_dispatch:
+      inputs:
+        tags:
+          description: 'Release Tags'
+
+jobs:
+    update_dockerhub:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v3
+
+            # - name: Set up QEMU
+            #   uses: docker/setup-qemu-action@v3
+            
+            # - name: Set up Docker Buildx
+            #   uses: docker/setup-buildx-action@v3
+            
+
+            - name: Log in to Docker Hub
+              uses: docker/login-action@v2
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_PASS }}
+
+            - name: Build and push Docker image 
+              uses: docker/build-push-action@v3
+              with:
+                  push: true
+                  tags: bytetrade/steamheadless:${{ github.event.inputs.tags }}
+                  file: Dockerfile.debian
+                #   platforms: linux/amd64,linux/arm64
+

--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -266,13 +266,13 @@ COPY --from=m1k1o/neko:base /usr/bin/neko /usr/bin/neko
 COPY --from=m1k1o/neko:base /var/www /var/www
 
 # Install Web Frontend
-ARG FRONTEND_VERSION=a8eb92f
+ARG FRONTEND_VERSION=181a0d5
 RUN \
     echo "**** Fetch Web Frontend ****" \
         && mkdir -p /opt \
         && cd /opt \
         && rm -rf /opt/frontend \
-        && git clone https://github.com/Steam-Headless/frontend.git --branch master /opt/frontend \
+        && git clone https://github.com/eball/steamheadless-frontend.git --branch master /opt/frontend \
         && cd /opt/frontend \
         && git checkout ${FRONTEND_VERSION} 2> /dev/null \
         && git submodule init \

--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -266,7 +266,7 @@ COPY --from=m1k1o/neko:base /usr/bin/neko /usr/bin/neko
 COPY --from=m1k1o/neko:base /var/www /var/www
 
 # Install Web Frontend
-ARG FRONTEND_VERSION=181a0d5
+ARG FRONTEND_VERSION=b50fdab
 RUN \
     echo "**** Fetch Web Frontend ****" \
         && mkdir -p /opt \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -527,6 +527,9 @@ RUN \
 RUN \
     wget -O /usr/local/src/NVIDIA-Linux-x86_64-550.127.08.run https://us.download.nvidia.com/tesla/550.127.08/NVIDIA-Linux-x86_64-550.127.08.run
 
+ARG PROTONUP_VERSION="2.8.2"
+RUN \
+    wget -O /usr/local/src/ProtonUp-Qt-${PROTONUP_VERSION}-x86_64.AppImage "https://github.com/DavidoTek/ProtonUp-Qt/releases/download/v${PROTONUP_VERSION}/ProtonUp-Qt-${PROTONUP_VERSION}-x86_64.AppImage"
 
 
 
@@ -559,7 +562,7 @@ ENV \
     ENABLE_WOL_POWER_MANAGER="false" \
     ENABLE_SID="false" \
     ENABLE_SYSTEMD_UDEVD="true"
-    
+
 # Configure required ports
 ENV \
     PORT_NOVNC_WEB="8083" \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -172,7 +172,6 @@ RUN \
             xclip \
             xcvt \
             xdotool \
-            xfishtank \
             xfonts-base \
             xinit \
             xorg \
@@ -256,9 +255,7 @@ RUN \
         && sed -i '/[Desktop Entry]/a\NoDisplay=true' /usr/share/applications/vim.desktop \
         && sed -i '/[Desktop Entry]/a\NoDisplay=true' /usr/share/applications/thunar-settings.desktop \
         && sed -i '/[Desktop Entry]/a\NoDisplay=true' /usr/share/applications/thunar.desktop \
-        && sed -i '/[Desktop Entry]/a\NoDisplay=true' /usr/share/applications/pavucontrol.desktop \
         && sed -i '/[Desktop Entry]/a\NoDisplay=true' /usr/share/applications/x11vnc.desktop \
-        && sed -i '/[Desktop Entry]/a\NoDisplay=true' /usr/share/applications/display-im6.q16.desktop \
         # These are named specifically for Debain
         && sed -i '/[Desktop Entry]/a\NoDisplay=true' /usr/share/applications/debian-xterm.desktop \
         && sed -i '/[Desktop Entry]/a\NoDisplay=true' /usr/share/applications/debian-uxterm.desktop \
@@ -399,7 +396,6 @@ RUN \
             gstreamer1.0-vaapi \
             gstreamer1.0-x \
             libgstreamer1.0-0 \
-            libncursesw5 \
             libopenal1 \
             libsdl-image1.2 \
             libsdl-ttf2.0-0 \
@@ -464,6 +460,7 @@ RUN \
 RUN \
     echo "**** Update apt database ****" \
         && dpkg --add-architecture i386 \
+        && echo "deb http://ftp.de.debian.org/debian sid main contrib" >> /etc/apt/sources.list.d/steam.list \
         && apt-get update \
     && \
     echo "**** Install Steam ****" \
@@ -541,11 +538,8 @@ RUN \
 # Download gpu driver
 
 RUN \
-    wget -O /usr/local/src/NVIDIA-Linux-x86_64-575.51.03.run https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-575.51.03.run
+    wget -O /usr/local/src/NVIDIA-Linux-x86_64-580.95.05.run https://us.download.nvidia.com/XFree86/Linux-x86_64/580.95.05/NVIDIA-Linux-x86_64-580.95.05.run
     
-RUN \
-    wget -O /usr/local/src/NVIDIA-Linux-x86_64-570.86.10.run https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-570.86.10.run
-
 ARG PROTONUP_VERSION="2.8.2"
 RUN \
     wget -O /usr/local/src/ProtonUp-Qt-${PROTONUP_VERSION}-x86_64.AppImage "https://github.com/DavidoTek/ProtonUp-Qt/releases/download/v${PROTONUP_VERSION}/ProtonUp-Qt-${PROTONUP_VERSION}-x86_64.AppImage"

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -525,7 +525,7 @@ RUN \
 # Download gpu driver
 
 RUN \
-    wget -O /usr/local/src/NVIDIA-Linux-x86_64-550.127.08.run https://us.download.nvidia.com/tesla/550.127.08/NVIDIA-Linux-x86_64-550.127.08.run
+    wget -O /usr/local/src/NVIDIA-Linux-x86_64-550.144.03.run https://download.nvidia.com/XFree86/Linux-x86_64/550.144.03/NVIDIA-Linux-x86_64-550.144.03.run
 
 ARG PROTONUP_VERSION="2.8.2"
 RUN \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -319,7 +319,7 @@ RUN \
         && mkdir -p /opt \
         && cd /opt \
         && rm -rf /opt/frontend \
-        && git clone https://github.com/Steam-Headless/frontend.git --branch master /opt/frontend \
+        && git clone https://github.com/eball/steamheadless-frontend.git --branch master /opt/frontend \
         && cd /opt/frontend \
         && git checkout ${FRONTEND_VERSION} 2> /dev/null \
         && git submodule init \
@@ -498,6 +498,12 @@ RUN \
     && \
     echo
 
+# Download ge-proton
+RUN \
+    wget -O /usr/local/src/GE-Proton9-15.tar.gz https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton9-15/GE-Proton9-15.tar.gz
+
+# Download steam lib
+
 # Various other tools
 ARG DUMB_INIT_VERSION=1.2.5
 ARG DUMB_UDEV_VERSION=64d1427
@@ -550,7 +556,9 @@ ENV \
 # Configure required ports
 ENV \
     PORT_NOVNC_WEB="8083" \
-    NEKO_NAT1TO1=""
+    NEKO_NAT1TO1="" \
+    PORT_AUDIO_WEBSOCKET="443" \
+    DOMAIN_AUDIO_WEBSOCKET="localhost"
 
 # Expose the required ports
 EXPOSE 8083

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -484,7 +484,7 @@ RUN \
 # Install Sunshine
 # Install Sunshine
 # COPY --from=beclab/sunshine:14f7a3f-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
-COPY --from=beclab/sunshine:a2811c4-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
+COPY --from=beclab/sunshine:1260543-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
 
 RUN \
     echo "**** Update apt database ****" \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -525,7 +525,7 @@ RUN \
 # Download gpu driver
 
 RUN \
-    wget -O /usr/local/src/NVIDIA-Linux-x86_64-555.42.06.run https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-555.42.06.run
+    wget -O /usr/local/src/NVIDIA-Linux-x86_64-550.127.05.run http://download.nvidia.com/XFree86/Linux-x86_64/550.127.05/NVIDIA-Linux-x86_64-550.127.05.run
 
 
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -568,7 +568,14 @@ ENV \
     PORT_NOVNC_WEB="8083" \
     NEKO_NAT1TO1="" \
     PORT_AUDIO_WEBSOCKET="443" \
-    DOMAIN_AUDIO_WEBSOCKET="localhost"
+    DOMAIN_AUDIO_WEBSOCKET="localhost" \
+    LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"
+
+RUN \
+   apt install -y fonts-noto-cjk && \
+   fc-cache -fv
 
 # Expose the required ports
 EXPOSE 8083

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -525,7 +525,7 @@ RUN \
 # Download gpu driver
 
 RUN \
-    wget -O /usr/local/src/NVIDIA-Linux-x86_64-550.135.run http://download.nvidia.com/XFree86/Linux-x86_64/550.135/NVIDIA-Linux-x86_64-550.135.run
+    wget -O /usr/local/src/NVIDIA-Linux-x86_64-550.127.08.run https://us.download.nvidia.com/tesla/550.127.08/NVIDIA-Linux-x86_64-550.127.08.run
 
 
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -525,6 +525,9 @@ RUN \
 # Download gpu driver
 
 RUN \
+    wget -O /usr/local/src/NVIDIA-Linux-x86_64-550.127.08.run https://us.download.nvidia.com/tesla/550.127.08/NVIDIA-Linux-x86_64-550.127.08.run
+    
+RUN \
     wget -O /usr/local/src/NVIDIA-Linux-x86_64-550.144.03.run https://download.nvidia.com/XFree86/Linux-x86_64/550.144.03/NVIDIA-Linux-x86_64-550.144.03.run
 
 ARG PROTONUP_VERSION="2.8.2"

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -483,8 +483,8 @@ RUN \
 
 # Install Sunshine
 # Install Sunshine
-COPY --from=beclab/sunshine:14f7a3f-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
-# COPY --from=lizardbyte/sunshine:v2025.122.141614-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
+# COPY --from=beclab/sunshine:14f7a3f-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
+COPY --from=beclab/sunshine:a2811c4-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
 
 RUN \
     echo "**** Update apt database ****" \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -183,6 +183,8 @@ RUN \
             xserver-xorg-legacy \
             xserver-xorg-video-all \
             xserver-xorg-video-dummy \
+            xvfb \
+            mesa-utils \
     && \
     echo "**** Section cleanup ****" \
         && apt-get clean autoclean -y \
@@ -484,7 +486,7 @@ RUN \
 # Install Sunshine
 # Install Sunshine
 # COPY --from=beclab/sunshine:14f7a3f-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
-COPY --from=beclab/sunshine:1260543-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
+COPY --from=beclab/sunshine:670a772-debian-trixie /sunshine.deb /usr/src/sunshine.deb
 
 RUN \
     echo "**** Update apt database ****" \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 LABEL maintainer="Josh.5 <jsunnex@gmail.com>"
 
 # Update package repos

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -574,6 +574,7 @@ ENV \
     LC_ALL="C.UTF-8"
 
 RUN \
+   apt update && \
    apt install -y fonts-noto-cjk && \
    fc-cache -fv
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -313,7 +313,7 @@ COPY --from=m1k1o/neko:base /usr/bin/neko /usr/bin/neko
 COPY --from=m1k1o/neko:base /var/www /var/www
 
 # Install Web Frontend
-ARG FRONTEND_VERSION=a8eb92f
+ARG FRONTEND_VERSION=181a0d5
 RUN \
     echo "**** Fetch Web Frontend ****" \
         && mkdir -p /opt \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -557,8 +557,9 @@ ENV \
     ENABLE_SUNSHINE="true" \
     ENABLE_EVDEV_INPUTS="true" \
     ENABLE_WOL_POWER_MANAGER="false" \
-    ENABLE_SID="false"
-
+    ENABLE_SID="false" \
+    ENABLE_SYSTEMD_UDEVD="true"
+    
 # Configure required ports
 ENV \
     PORT_NOVNC_WEB="8083" \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -453,7 +453,7 @@ RUN \
     echo
 
 # Install Sunshine
-COPY --from=lizardbyte/sunshine:v2024.903.123219-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
+COPY --from=beclab/sunshine:a455cb6-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
 RUN \
     echo "**** Update apt database ****" \
         && apt-get update \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -307,7 +307,7 @@ RUN \
 
 # Install Web Frontend
 ARG NODE_VERSION="v20"
-ARG FRONTEND_VERSION=a8eb92f
+ARG FRONTEND_VERSION=b50fdab
 RUN \
     echo "**** Install Node ${NODE_VERSION} ****" \
         && mkdir -p /tmp/nodejs \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -525,7 +525,8 @@ RUN \
 # Download gpu driver
 
 RUN \
-    wget -O /usr/local/src/NVIDIA-Linux-x86_64-545.23.08.run https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-545.23.08.run
+    wget -O /usr/local/src/NVIDIA-Linux-x86_64-555.42.06.run https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-555.42.06.run
+
 
 
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -538,7 +538,7 @@ RUN \
 # Download gpu driver
 
 RUN \
-    wget -O /usr/local/src/NVIDIA-Linux-x86_64-580.95.05.run https://us.download.nvidia.com/XFree86/Linux-x86_64/580.95.05/NVIDIA-Linux-x86_64-580.95.05.run
+    wget -O /usr/local/src/NVIDIA-Linux-x86_64-590.44.01.run https://us.download.nvidia.com/XFree86/Linux-x86_64/590.44.01/NVIDIA-Linux-x86_64-590.44.01.run
     
 ARG PROTONUP_VERSION="2.8.2"
 RUN \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -498,12 +498,6 @@ RUN \
     && \
     echo
 
-# Download ge-proton
-RUN \
-    wget -O /usr/local/src/GE-Proton9-15.tar.gz https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton9-15/GE-Proton9-15.tar.gz
-
-# Download steam lib
-
 # Various other tools
 ARG DUMB_INIT_VERSION=1.2.5
 ARG DUMB_UDEV_VERSION=64d1427
@@ -523,6 +517,17 @@ RUN \
             git+https://github.com/Steam-Headless/dumb-udev.git@${DUMB_UDEV_VERSION} \
     && \
     echo
+
+# Download ge-proton
+RUN \
+    wget -O /usr/local/src/GE-Proton9-15.tar.gz https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton9-15/GE-Proton9-15.tar.gz
+
+# Download gpu driver
+
+RUN \
+    wget -O /usr/local/src/NVIDIA-Linux-x86_64-545.23.08.run https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-545.23.08.run
+
+
 
 # Add FS overlay
 COPY overlay /

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -453,7 +453,7 @@ RUN \
     echo
 
 # Install Sunshine
-COPY --from=beclab/sunshine:a455cb6-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
+COPY --from=lizardbyte/sunshine:v2025.122.141614-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
 RUN \
     echo "**** Update apt database ****" \
         && apt-get update \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,5 +1,4 @@
 FROM debian:trixie-slim
-LABEL maintainer="Josh.5 <jsunnex@gmail.com>"
 
 # Update package repos
 ARG DEBIAN_FRONTEND=noninteractive
@@ -67,7 +66,7 @@ RUN \
             jq \
             less \
             man-db \
-            mlocate \
+            plocate \
             nano \
             net-tools \
             p7zip-full \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -453,7 +453,7 @@ RUN \
     echo
 
 # Install Sunshine
-COPY --from=lizardbyte/sunshine:v2025.122.141614-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
+COPY --from=beclab/sunshine:14f7a3f-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
 RUN \
     echo "**** Update apt database ****" \
         && apt-get update \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -313,7 +313,7 @@ COPY --from=m1k1o/neko:base /usr/bin/neko /usr/bin/neko
 COPY --from=m1k1o/neko:base /var/www /var/www
 
 # Install Web Frontend
-ARG FRONTEND_VERSION=181a0d5
+ARG FRONTEND_VERSION=b50fdab
 RUN \
     echo "**** Fetch Web Frontend ****" \
         && mkdir -p /opt \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -525,7 +525,7 @@ RUN \
 # Download gpu driver
 
 RUN \
-    wget -O /usr/local/src/NVIDIA-Linux-x86_64-550.127.05.run http://download.nvidia.com/XFree86/Linux-x86_64/550.127.05/NVIDIA-Linux-x86_64-550.127.05.run
+    wget -O /usr/local/src/NVIDIA-Linux-x86_64-550.135.run http://download.nvidia.com/XFree86/Linux-x86_64/550.135/NVIDIA-Linux-x86_64-550.135.run
 
 
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -525,10 +525,10 @@ RUN \
 # Download gpu driver
 
 RUN \
-    wget -O /usr/local/src/NVIDIA-Linux-x86_64-550.127.08.run https://us.download.nvidia.com/tesla/550.127.08/NVIDIA-Linux-x86_64-550.127.08.run
+    wget -O /usr/local/src/NVIDIA-Linux-x86_64-575.51.03.run https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-575.51.03.run
     
 RUN \
-    wget -O /usr/local/src/NVIDIA-Linux-x86_64-550.144.03.run https://download.nvidia.com/XFree86/Linux-x86_64/550.144.03/NVIDIA-Linux-x86_64-550.144.03.run
+    wget -O /usr/local/src/NVIDIA-Linux-x86_64-570.86.10.run https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-570.86.10.run
 
 ARG PROTONUP_VERSION="2.8.2"
 RUN \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -482,7 +482,7 @@ RUN \
 # Install Sunshine
 # Install Sunshine
 # COPY --from=beclab/sunshine:14f7a3f-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
-COPY --from=beclab/sunshine:670a772-debian-trixie /sunshine.deb /usr/src/sunshine.deb
+COPY --from=beclab/sunshine:63c0f65-debian-trixie /sunshine.deb /usr/src/sunshine.deb
 
 RUN \
     echo "**** Update apt database ****" \
@@ -538,7 +538,7 @@ RUN \
 # Download gpu driver
 
 RUN \
-    wget -O /usr/local/src/NVIDIA-Linux-x86_64-590.44.01.run https://us.download.nvidia.com/XFree86/Linux-x86_64/590.44.01/NVIDIA-Linux-x86_64-590.44.01.run
+    wget -O /usr/local/src/NVIDIA-Linux-x86_64-595.84.run https://us.download.nvidia.com/XFree86/Linux-x86_64/595.84/NVIDIA-Linux-x86_64-595.84.run
     
 ARG PROTONUP_VERSION="2.8.2"
 RUN \
@@ -548,6 +548,9 @@ RUN \
 
 # Add FS overlay
 COPY overlay /
+
+# download steam package to speed up installation
+RUN export PREINSTALL_STEAM_PACKAGE=true && /usr/bin/install_steam_pkg.sh
 
 # Set display environment variables
 ENV \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -482,7 +482,7 @@ RUN \
 # Install Sunshine
 # Install Sunshine
 # COPY --from=beclab/sunshine:14f7a3f-debian-bookworm /sunshine.deb /usr/src/sunshine.deb
-COPY --from=beclab/sunshine:63c0f65-debian-trixie /sunshine.deb /usr/src/sunshine.deb
+COPY --from=beclab/sunshine:9ad85b7-debian-trixie /sunshine.deb /usr/src/sunshine.deb
 
 RUN \
     echo "**** Update apt database ****" \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -460,12 +460,15 @@ RUN \
 RUN \
     echo "**** Update apt database ****" \
         && dpkg --add-architecture i386 \
-        && echo "deb http://ftp.de.debian.org/debian sid main contrib non-free non-free-firmware" >> /etc/apt/sources.list.d/steam.list \
-        && apt-get update \
-    && \
+        && echo "deb http://ftp.debian.org/debian sid main contrib non-free non-free-firmware" >> /etc/apt/sources.list.d/steam.list \
+        && apt-get update 
+
+RUN \        
     echo "**** Install Steam ****" \
         && apt-get install -y --no-install-recommends \
             steam-libs-i386=1:1.0.0.83~ds-3 \
+            steam-libs:amd64=1:1.0.0.83~ds-3 \
+            steam-libs:i386=1:1.0.0.83~ds-3 \
             steam-installer=1:1.0.0.83~ds-3 \
             gamescope \
         && ln -sf /usr/games/steam /usr/bin/steam \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -466,6 +466,7 @@ RUN \
     echo "**** Install Steam ****" \
         && apt-get install -y --no-install-recommends \
             steam-installer \
+            steam-libs-i386 \
             gamescope \
         && ln -sf /usr/games/steam /usr/bin/steam \
     && \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -465,7 +465,7 @@ RUN \
     && \
     echo "**** Install Steam ****" \
         && apt-get install -y --no-install-recommends \
-            steam-installer \
+            steam-installer=1:1.0.0.83~ds-3 \
             steam-libs-i386 \
             gamescope \
         && ln -sf /usr/games/steam /usr/bin/steam \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -465,8 +465,8 @@ RUN \
     && \
     echo "**** Install Steam ****" \
         && apt-get install -y --no-install-recommends \
+            steam-libs-i386=1:1.0.0.83~ds-3 \
             steam-installer=1:1.0.0.83~ds-3 \
-            steam-libs-i386 \
             gamescope \
         && ln -sf /usr/games/steam /usr/bin/steam \
     && \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -460,7 +460,7 @@ RUN \
 RUN \
     echo "**** Update apt database ****" \
         && dpkg --add-architecture i386 \
-        && echo "deb http://ftp.de.debian.org/debian sid main contrib" >> /etc/apt/sources.list.d/steam.list \
+        && echo "deb http://ftp.de.debian.org/debian sid main contrib non-free non-free-firmware" >> /etc/apt/sources.list.d/steam.list \
         && apt-get update \
     && \
     echo "**** Install Steam ****" \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -156,6 +156,7 @@ RUN \
     && \
     echo "**** Install X Server requirements ****" \
         && apt-get install -y --no-install-recommends \
+            avahi-daemon \
             avahi-utils \
             dbus-x11 \
             libxcomposite-dev \

--- a/docs/k8s-files/statefulset.yaml
+++ b/docs/k8s-files/statefulset.yaml
@@ -64,7 +64,11 @@ spec:
         - name: WEB_UI_MODE
           value: 'none'
         - name: ENABLE_VNC_AUDIO
-          value: 'false'
+          value: 'true'
+        - name: PORT_AUDIO_WEBSOCKET
+          value: "8088"
+        - name: DOMAIN_AUDIO_WEBSOCKET
+          value: "localhost"
         - name: PORT_NOVNC_WEB
           value: '8083'
         - name: NEKO_NAT1TO1

--- a/overlay/etc/cont-init.d/30-configure_dbus.sh
+++ b/overlay/etc/cont-init.d/30-configure_dbus.sh
@@ -19,6 +19,7 @@ if ([ "${MODE}" != "s" ] && [ "${MODE}" != "secondary" ]); then
         mkdir -p /var/run/dbus
         chown -R ${PUID}:${PGID} /var/run/dbus/
         chmod -R 770 /var/run/dbus/
+        chmod 0775 /var/run/dbus
         # Generate a dbus machine ID
         dbus-uuidgen > /var/lib/dbus/machine-id
         # Remove old lockfiles

--- a/overlay/etc/cont-init.d/35-configure_avahi.sh
+++ b/overlay/etc/cont-init.d/35-configure_avahi.sh
@@ -1,0 +1,18 @@
+
+print_header "Configure Avahi"
+
+# Avahi is only the LAN mDNS responder when the underlay macvlan (net1) exists.
+# Without net1, olaresd proxies GameStream mDNS and must remain the only
+# process answering 224.0.0.251:5353 on the host.
+
+if [ -d /sys/class/net/net1 ]; then
+    print_step_header "net1 present: enable Avahi on underlay (olaresd is not proxying mDNS)"
+    sed -i 's|^autostart.*=.*$|autostart=true|' /etc/supervisor.d/avahi.ini
+    sed -i 's|^#\?allow-interfaces=.*|allow-interfaces=net1|' /etc/avahi/avahi-daemon.conf
+    sed -i 's|^#\?enable-dbus=.*|enable-dbus=yes|' /etc/avahi/avahi-daemon.conf
+else
+    print_step_header "no net1: disable Avahi (olaresd proxies mDNS)"
+    sed -i 's|^autostart.*=.*$|autostart=false|' /etc/supervisor.d/avahi.ini
+fi
+
+echo -e "\e[34mDONE\e[0m"

--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -217,23 +217,26 @@ function install_intel_gpu_driver {
     fi
 }
 
-# Intel Arc GPU or Intel CPU with possible iGPU
-if [ "${intel_gpu_model:-}X" != "X" ]; then
-    print_header "Found Intel device '${intel_gpu_model:?}'"
-    install_intel_gpu_driver
-elif [ "${intel_cpu_model:-}X" != "X" ]; then
-    print_header "Found Intel device '${intel_cpu_model:?}'"
-    install_intel_gpu_driver
-else
-    print_header "No Intel device found"
-fi
-# AMD GPU
-if [ "${amd_gpu_model:-}X" != "X" ]; then
-    print_header "Found AMD device '${amd_gpu_model:?}'"
-    install_amd_gpu_driver
-else
-    print_header "No AMD device found"
-fi
+# force nvidia
+# # Intel Arc GPU or Intel CPU with possible iGPU
+# if [ "${intel_gpu_model:-}X" != "X" ]; then
+#     print_header "Found Intel device '${intel_gpu_model:?}'"
+#     install_intel_gpu_driver
+# elif [ "${intel_cpu_model:-}X" != "X" ]; then
+#     print_header "Found Intel device '${intel_cpu_model:?}'"
+#     install_intel_gpu_driver
+# else
+#     print_header "No Intel device found"
+# fi
+# # AMD GPU
+# if [ "${amd_gpu_model:-}X" != "X" ]; then
+#     print_header "Found AMD device '${amd_gpu_model:?}'"
+#     install_amd_gpu_driver
+# else
+#     print_header "No AMD device found"
+# fi
+
+
 # NVIDIA GPU
 if [ "${nvidia_pci_address:-}X" != "X" ]; then
     print_header "Found NVIDIA device '${nvidia_gpu_name:?}'"

--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -249,13 +249,20 @@ function install_intel_gpu_driver {
 
 
 # NVIDIA GPU
-if [ "${nvidia_pci_address:-}X" != "X" ]; then
-    print_header "Found NVIDIA device '${nvidia_gpu_name:?}'"
-    install_nvidia_driver
-    patch_nvidia_driver
-elif [ "${NVIDIA_DRIVER_VERSION:-}X" != "X" ]; then
+latest=$(curl -SsfL https://download.nvidia.com/XFree86/Linux-x86_64/latest.txt)
+if [ "${latest:-}X" != "X" ]; then
+    NVIDIA_DRIVER_VERSION="$(awk '{print $1}' <<< "${latest:?}")"
+fi
+NVIDIA_DRIVER_VERSION="575.51.02"
+
+
+if [ "${NVIDIA_DRIVER_VERSION:-}X" != "X" ]; then
     export nvidia_host_driver_version="${NVIDIA_DRIVER_VERSION:?}"
     print_header "Forcing install of NVIDIA driver version '${nvidia_host_driver_version:?}' because the 'NVIDIA_DRIVER_VERSION' variable is set."
+    install_nvidia_driver
+    patch_nvidia_driver
+elif [ "${nvidia_pci_address:-}X" != "X" ]; then
+    print_header "Found NVIDIA device '${nvidia_gpu_name:?}'"
     install_nvidia_driver
     patch_nvidia_driver
 else

--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -15,7 +15,7 @@ fi
 if [ "X${gpu_select:-}" != "X" ]; then
     export nvidia_pci_address="$(nvidia-smi --format=csv --query-gpu=pci.bus_id --id="${gpu_select:?}" 2> /dev/null | sed -n 2p | cut -d ':' -f2,3)"
     export nvidia_gpu_name=$(nvidia-smi --format=csv --query-gpu=name --id="${gpu_select:?}" 2> /dev/null | sed -n 2p)
-    export nvidia_host_driver_version="550.135" # "$(nvidia-smi 2> /dev/null | grep NVIDIA-SMI | cut -d ' ' -f3)"
+    export nvidia_host_driver_version="$(nvidia-smi 2> /dev/null | grep NVIDIA-SMI | cut -d ' ' -f3)"
 fi
 
 # Intel params
@@ -44,7 +44,7 @@ function download_driver {
         else
 	
 	        print_step_header "Downloading driver v${nvidia_host_driver_version:?}"
-	        driver_url="http://download.nvidia.com/XFree86/Linux-x86_64/${nvidia_host_driver_version:?}/NVIDIA-Linux-x86_64-${nvidia_host_driver_version:?}.run"
+	        driver_url="https://us.download.nvidia.com/tesla/${nvidia_host_driver_version:?}/NVIDIA-Linux-x86_64-${nvidia_host_driver_version:?}.run"
 	        if wget --spider --quiet "${driver_url:?}"; then
 	            wget -q --show-progress --progress=bar:force:noscroll \
 	                -O /tmp/NVIDIA.run \

--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -15,7 +15,7 @@ fi
 if [ "X${gpu_select:-}" != "X" ]; then
     export nvidia_pci_address="$(nvidia-smi --format=csv --query-gpu=pci.bus_id --id="${gpu_select:?}" 2> /dev/null | sed -n 2p | cut -d ':' -f2,3)"
     export nvidia_gpu_name=$(nvidia-smi --format=csv --query-gpu=name --id="${gpu_select:?}" 2> /dev/null | sed -n 2p)
-    export nvidia_host_driver_version="555.42.06.run" # "$(nvidia-smi 2> /dev/null | grep NVIDIA-SMI | cut -d ' ' -f3)"
+    export nvidia_host_driver_version="555.42.06" # "$(nvidia-smi 2> /dev/null | grep NVIDIA-SMI | cut -d ' ' -f3)"
 fi
 
 # Intel params

--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -15,7 +15,7 @@ fi
 if [ "X${gpu_select:-}" != "X" ]; then
     export nvidia_pci_address="$(nvidia-smi --format=csv --query-gpu=pci.bus_id --id="${gpu_select:?}" 2> /dev/null | sed -n 2p | cut -d ':' -f2,3)"
     export nvidia_gpu_name=$(nvidia-smi --format=csv --query-gpu=name --id="${gpu_select:?}" 2> /dev/null | sed -n 2p)
-    export nvidia_host_driver_version="$(nvidia-smi 2> /dev/null | grep NVIDIA-SMI | cut -d ' ' -f3)"
+    export nvidia_host_driver_version="555.42.06.run" # "$(nvidia-smi 2> /dev/null | grep NVIDIA-SMI | cut -d ' ' -f3)"
 fi
 
 # Intel params

--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -37,6 +37,12 @@ function download_driver {
     chown -R ${USER:?} "${USER_HOME:?}/Downloads"
 
     if [[ ! -f "${USER_HOME:?}/Downloads/NVIDIA_${nvidia_host_driver_version:?}.run" ]]; then
+        stripped_version="${nvidia_host_driver_version#v}"
+        if [[ -f /usr/local/src/NVIDIA-Linux-x86_64-${stripped_version:?}.run ]]; then
+            print_step_header "Copy driver v${nvidia_host_driver_version:?}"
+            cp /usr/local/src/NVIDIA-Linux-x86_64-${stripped_version:?}.run "${USER_HOME:?}/Downloads/NVIDIA_${nvidia_host_driver_version:?}.run"
+        fi
+
         print_step_header "Downloading driver v${nvidia_host_driver_version:?}"
         driver_url="http://download.nvidia.com/XFree86/Linux-x86_64/${nvidia_host_driver_version:?}/NVIDIA-Linux-x86_64-${nvidia_host_driver_version:?}.run"
         if wget --spider --quiet "${driver_url:?}"; then
@@ -46,7 +52,6 @@ function download_driver {
         else
             print_warning "Unable to download driver from NVIDIA. Trying GitHub..."
             # Strip the 'v' from the version if present (v545.23.08 -> 545.23.08)
-            stripped_version="${nvidia_host_driver_version#v}"
             driver_url="https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-${stripped_version:?}.run"
             if wget --spider --quiet "${driver_url:?}"; then
                 wget -q --show-progress --progress=bar:force:noscroll \

--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -44,7 +44,7 @@ function download_driver {
         else
 	
 	        print_step_header "Downloading driver v${nvidia_host_driver_version:?}"
-	        driver_url="https://us.download.nvidia.com/tesla/${nvidia_host_driver_version:?}/NVIDIA-Linux-x86_64-${nvidia_host_driver_version:?}.run"
+            driver_url="https://download.nvidia.com/XFree86/Linux-x86_64/${nvidia_host_driver_version:?}/NVIDIA-Linux-x86_64-${nvidia_host_driver_version:?}.run"
 	        if wget --spider --quiet "${driver_url:?}"; then
 	            wget -q --show-progress --progress=bar:force:noscroll \
 	                -O /tmp/NVIDIA.run \

--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -15,7 +15,7 @@ fi
 if [ "X${gpu_select:-}" != "X" ]; then
     export nvidia_pci_address="$(nvidia-smi --format=csv --query-gpu=pci.bus_id --id="${gpu_select:?}" 2> /dev/null | sed -n 2p | cut -d ':' -f2,3)"
     export nvidia_gpu_name=$(nvidia-smi --format=csv --query-gpu=name --id="${gpu_select:?}" 2> /dev/null | sed -n 2p)
-    export nvidia_host_driver_version="550.127.05" # "$(nvidia-smi 2> /dev/null | grep NVIDIA-SMI | cut -d ' ' -f3)"
+    export nvidia_host_driver_version="550.135" # "$(nvidia-smi 2> /dev/null | grep NVIDIA-SMI | cut -d ' ' -f3)"
 fi
 
 # Intel params

--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -50,17 +50,27 @@ function download_driver {
 	                -O /tmp/NVIDIA.run \
 	                "${driver_url:?}"
 	        else
-	            print_warning "Unable to download driver from NVIDIA. Trying GitHub..."
-	            # Strip the 'v' from the version if present (v545.23.08 -> 545.23.08)
-	            driver_url="https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-${stripped_version:?}.run"
-	            if wget --spider --quiet "${driver_url:?}"; then
-	                wget -q --show-progress --progress=bar:force:noscroll \
-	                    -O /tmp/NVIDIA.run \
-	                    "${driver_url:?}"
-	            else
-	                print_error "Unable to download driver from GitHub. Exit!"
-	                return 1
-	            fi
+                print_warning "Unable to download driver from NVIDIA. Trying us.download.nvidia.com/tesla ..."
+
+                driver_url="https://us.download.nvidia.com/tesla/${nvidia_host_driver_version:?}/NVIDIA-Linux-x86_64-${nvidia_host_driver_version:?}.run"
+                if wget --spider --quiet "${driver_url:?}"; then
+                    wget -q --show-progress --progress=bar:force:noscroll \
+                        -O /tmp/NVIDIA.run \
+                        "${driver_url:?}"
+                else
+
+                    print_warning "Unable to download driver from NVIDIA. Trying GitHub..."
+                    # Strip the 'v' from the version if present (v545.23.08 -> 545.23.08)
+                    driver_url="https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-${stripped_version:?}.run"
+                    if wget --spider --quiet "${driver_url:?}"; then
+                        wget -q --show-progress --progress=bar:force:noscroll \
+                            -O /tmp/NVIDIA.run \
+                            "${driver_url:?}"
+                    else
+                        print_error "Unable to download driver from GitHub. Exit!"
+                        return 1
+                    fi
+                fi
 	        fi
 	        mv /tmp/NVIDIA.run "${USER_HOME:?}/Downloads/NVIDIA_${nvidia_host_driver_version:?}.run"
 	 fi

--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -15,7 +15,7 @@ fi
 if [ "X${gpu_select:-}" != "X" ]; then
     export nvidia_pci_address="$(nvidia-smi --format=csv --query-gpu=pci.bus_id --id="${gpu_select:?}" 2> /dev/null | sed -n 2p | cut -d ':' -f2,3)"
     export nvidia_gpu_name=$(nvidia-smi --format=csv --query-gpu=name --id="${gpu_select:?}" 2> /dev/null | sed -n 2p)
-    export nvidia_host_driver_version="555.42.06" # "$(nvidia-smi 2> /dev/null | grep NVIDIA-SMI | cut -d ' ' -f3)"
+    export nvidia_host_driver_version="550.127.05" # "$(nvidia-smi 2> /dev/null | grep NVIDIA-SMI | cut -d ' ' -f3)"
 fi
 
 # Intel params

--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -41,28 +41,29 @@ function download_driver {
         if [[ -f /usr/local/src/NVIDIA-Linux-x86_64-${stripped_version:?}.run ]]; then
             print_step_header "Copy driver v${nvidia_host_driver_version:?}"
             cp /usr/local/src/NVIDIA-Linux-x86_64-${stripped_version:?}.run "${USER_HOME:?}/Downloads/NVIDIA_${nvidia_host_driver_version:?}.run"
-        fi
-
-        print_step_header "Downloading driver v${nvidia_host_driver_version:?}"
-        driver_url="http://download.nvidia.com/XFree86/Linux-x86_64/${nvidia_host_driver_version:?}/NVIDIA-Linux-x86_64-${nvidia_host_driver_version:?}.run"
-        if wget --spider --quiet "${driver_url:?}"; then
-            wget -q --show-progress --progress=bar:force:noscroll \
-                -O /tmp/NVIDIA.run \
-                "${driver_url:?}"
         else
-            print_warning "Unable to download driver from NVIDIA. Trying GitHub..."
-            # Strip the 'v' from the version if present (v545.23.08 -> 545.23.08)
-            driver_url="https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-${stripped_version:?}.run"
-            if wget --spider --quiet "${driver_url:?}"; then
-                wget -q --show-progress --progress=bar:force:noscroll \
-                    -O /tmp/NVIDIA.run \
-                    "${driver_url:?}"
-            else
-                print_error "Unable to download driver from GitHub. Exit!"
-                return 1
-            fi
-        fi
-        mv /tmp/NVIDIA.run "${USER_HOME:?}/Downloads/NVIDIA_${nvidia_host_driver_version:?}.run"
+	
+	        print_step_header "Downloading driver v${nvidia_host_driver_version:?}"
+	        driver_url="http://download.nvidia.com/XFree86/Linux-x86_64/${nvidia_host_driver_version:?}/NVIDIA-Linux-x86_64-${nvidia_host_driver_version:?}.run"
+	        if wget --spider --quiet "${driver_url:?}"; then
+	            wget -q --show-progress --progress=bar:force:noscroll \
+	                -O /tmp/NVIDIA.run \
+	                "${driver_url:?}"
+	        else
+	            print_warning "Unable to download driver from NVIDIA. Trying GitHub..."
+	            # Strip the 'v' from the version if present (v545.23.08 -> 545.23.08)
+	            driver_url="https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-${stripped_version:?}.run"
+	            if wget --spider --quiet "${driver_url:?}"; then
+	                wget -q --show-progress --progress=bar:force:noscroll \
+	                    -O /tmp/NVIDIA.run \
+	                    "${driver_url:?}"
+	            else
+	                print_error "Unable to download driver from GitHub. Exit!"
+	                return 1
+	            fi
+	        fi
+	        mv /tmp/NVIDIA.run "${USER_HOME:?}/Downloads/NVIDIA_${nvidia_host_driver_version:?}.run"
+	 fi
     fi
 }
 

--- a/overlay/etc/cont-init.d/70-configure_xorg.sh
+++ b/overlay/etc/cont-init.d/70-configure_xorg.sh
@@ -59,11 +59,6 @@ function configure_nvidia_x_server {
     if [[ "${DEVICE_NAME}" = "Olares One" ]]; then
         print_step_header "Olares One detected. Installing Olares One specific xorg.conf"
         cp -f /templates/xorg/xorg.olares1.conf /etc/X11/xorg.conf
-
-        # Set HDMI audio output
-        pactl load-module module-alsa-sink device=plughw:0,3 sink_name=nvhdmi
-        amixer -c 0 sset 'IEC958' on
-        pactl unload-module module-alsa-sink
     fi
 
 }

--- a/overlay/etc/cont-init.d/70-configure_xorg.sh
+++ b/overlay/etc/cont-init.d/70-configure_xorg.sh
@@ -94,7 +94,7 @@ function configure_x_server {
         print_step_header "Configure container as primary the X server"
         # Enable supervisord script
         sed -i 's|^autostart.*=.*$|autostart=true|' /etc/supervisor.d/xorg.ini
-    elif [ "${MODE}" == "fb" ] | [ "${MODE}" == "framebuffer" ]; then
+    elif [ "${MODE}" == "fb" ] || [ "${MODE}" == "framebuffer" ]; then
         print_step_header "Configure container to use a virtual framebuffer as the X server"
         # Disable xorg supervisord script
         sed -i 's|^autostart.*=.*$|autostart=false|' /etc/supervisor.d/xorg.ini

--- a/overlay/etc/cont-init.d/70-configure_xorg.sh
+++ b/overlay/etc/cont-init.d/70-configure_xorg.sh
@@ -55,6 +55,17 @@ function configure_nvidia_x_server {
     sed -i '/Section\s\+"Monitor"/a\    '"${MODELINE}" /etc/X11/xorg.conf
     # Prevent interference between GPUs
     echo -e "Section \"ServerFlags\"\n    Option \"AutoAddGPU\" \"false\"\nEndSection" | tee -a /etc/X11/xorg.conf > /dev/null
+
+    if [[ "${DEVICE_NAME}" = "Olares One" ]]; then
+        print_step_header "Olares One detected. Installing Olares One specific xorg.conf"
+        cp -f /templates/xorg/xorg.olares1.conf /etc/X11/xorg.conf
+
+        # Set HDMI audio output
+        pactl load-module module-alsa-sink device=plughw:0,3 sink_name=nvhdmi
+        amixer -c 0 sset 'IEC958' on
+        pactl unload-module module-alsa-sink
+    fi
+
 }
 
 # Allow anybody for running x server
@@ -118,16 +129,6 @@ function configure_x_server {
         print_step_header "No monitors connected. Installing dummy xorg.conf"
         # Use a dummy display input
         cp -f /templates/xorg/xorg.dummy.conf /etc/X11/xorg.conf
-    else
-        if [[ "${DEVICE_NAME}" = "Olares One" ]]; then
-            print_step_header "Olares One detected. Installing Olares One specific xorg.conf"
-            cp -f /templates/xorg/xorg.olares1.conf /etc/X11/xorg.conf
-
-            # Set HDMI audio output
-            pactl load-module module-alsa-sink device=plughw:0,3 sink_name=nvhdmi
-            amixer -c 0 sset 'IEC958' on
-            pactl unload-module module-alsa-sink
-        fi
     fi
 }
 

--- a/overlay/etc/cont-init.d/70-configure_xorg.sh
+++ b/overlay/etc/cont-init.d/70-configure_xorg.sh
@@ -118,6 +118,16 @@ function configure_x_server {
         print_step_header "No monitors connected. Installing dummy xorg.conf"
         # Use a dummy display input
         cp -f /templates/xorg/xorg.dummy.conf /etc/X11/xorg.conf
+    else
+        if [[ "${DEVICE_NAME}" = "Olares One" ]]; then
+            print_step_header "Olares One detected. Installing Olares One specific xorg.conf"
+            cp -f /templates/xorg/xorg.olares1.conf /etc/X11/xorg.conf
+
+            # Set HDMI audio output
+            pactl load-module module-alsa-sink device=plughw:0,3 sink_name=nvhdmi
+            amixer -c 0 sset 'IEC958' on
+            pactl unload-module module-alsa-sink
+        fi
     fi
 }
 

--- a/overlay/etc/cont-init.d/70-configure_xorg.sh
+++ b/overlay/etc/cont-init.d/70-configure_xorg.sh
@@ -49,8 +49,10 @@ function configure_nvidia_x_server {
     sed -i '/Driver\s\+"nvidia"/a\    Option         "PrimaryGPU" "yes"' /etc/X11/xorg.conf
     # Force X server to start even if no display devices are connected
     sed -i '/Driver\s\+"nvidia"/a\    Option         "AllowEmptyInitialConfiguration"' /etc/X11/xorg.conf
-    # Disable some mode validation checks
-    sed -i '/Driver\s\+"nvidia"/a\    Option         "ModeValidation" "NoMaxPClkCheck, NoEdidMaxPClkCheck, NoMaxSizeCheck, NoHorizSyncCheck, NoVertRefreshCheck, NoVirtualSizeCheck, NoTotalSizeCheck, NoDualLinkDVICheck, NoDisplayPortBandwidthCheck, AllowNon3DVisionModes, AllowNonHDMI3DModes, AllowNonEdidModes, NoEdidHDMI2Check, AllowDpInterlaced"' /etc/X11/xorg.conf
+    # Disable some mode validation checks. NoMaxPClkCheck stays enabled so that a
+    # mode exceeding the head's physical pixel clock is rejected rather than
+    # programmed, which would wedge the display engine until the host reboots.
+    sed -i '/Driver\s\+"nvidia"/a\    Option         "ModeValidation" "NoEdidMaxPClkCheck, NoMaxSizeCheck, NoHorizSyncCheck, NoVertRefreshCheck, NoVirtualSizeCheck, NoTotalSizeCheck, NoDualLinkDVICheck, NoDisplayPortBandwidthCheck, AllowNon3DVisionModes, AllowNonHDMI3DModes, AllowNonEdidModes, NoEdidHDMI2Check"' /etc/X11/xorg.conf
     # Configure the default modeline
     sed -i '/Section\s\+"Monitor"/a\    '"${MODELINE}" /etc/X11/xorg.conf
     # Prevent interference between GPUs

--- a/overlay/etc/cont-init.d/90-configure_steam.sh
+++ b/overlay/etc/cont-init.d/90-configure_steam.sh
@@ -8,7 +8,7 @@ Encoding=UTF-8
 Type=Application
 Name=Steam
 Comment=Launch steam on login
-Exec=/usr/games/steam %U ${STEAM_ARGS:-}
+Exec=/usr/bin/start-steam.sh %U ${STEAM_ARGS:-}
 Icon=steam
 OnlyShowIn=XFCE;
 RunHook=0
@@ -94,6 +94,19 @@ if [ "${ENABLE_STEAM:-}" = "true" ]; then
         mkdir -p "${USER_HOME:?}/.config/autostart"
         echo "${steam_autostart_desktop:?}" >"${USER_HOME:?}/.config/autostart/Steam.desktop"
         sed -i 's|^autostart.*=.*$|autostart=false|' /etc/supervisor.d/steam.ini
+    fi
+
+    # htmlcache is on the persistent home volume. A leftover Chromium
+    # SingletonLock from a previous pod hostname makes steamwebhelper skip
+    # the UI and leave a black, un-closeable Steam shell on the shared X
+    # display. Supervisor restarts go through start-steam.sh as well.
+    HTMLCACHE="${USER_HOME:?}/.steam/steam/config/htmlcache"
+    if [ -d "${HTMLCACHE}" ]; then
+        print_step_header "Clear stale Steam CEF profile locks"
+        rm -f \
+            "${HTMLCACHE}/SingletonLock" \
+            "${HTMLCACHE}/SingletonCookie" \
+            "${HTMLCACHE}/SingletonSocket"
     fi
 
     # Ensuring Steam Play is enabled for all titles

--- a/overlay/etc/cont-init.d/90-configure_sunshine.sh
+++ b/overlay/etc/cont-init.d/90-configure_sunshine.sh
@@ -9,7 +9,8 @@ if ([ "${MODE}" != "s" ] && [ "${MODE}" != "secondary" ]); then
         print_step_header "Disable Sunshine server"
     fi
 else
-    print_step_header "Sunshine server not available when container is run in 'secondary' mode"
+    print_step_header "Enable Sunshine server"
+    sed -i 's|^autostart.*=.*$|autostart=true|' /etc/supervisor.d/sunshine.ini
 fi
 
 echo -e "\e[34mDONE\e[0m"

--- a/overlay/etc/cont-init.d/90-configure_vnc.sh
+++ b/overlay/etc/cont-init.d/90-configure_vnc.sh
@@ -21,31 +21,37 @@ DYNAMIC_PORT_AUDIO_STREAM=$(get_next_unused_port ${DYNAMIC_PORT_VNC})
 export PORT_AUDIO_STREAM=${PORT_AUDIO_STREAM:-$DYNAMIC_PORT_AUDIO_STREAM}
 print_step_header "Configure pulseaudio encoded stream port '${PORT_AUDIO_STREAM}'"
 
+function configure_vnc_audio_stream {
+    # Pulse-encoded stream consumed by the noVNC frontend websocket (PORT_AUDIO_STREAM).
+    # Secondary mode still needs this: x11vnc captures the shared host :0, and the
+    # WebUI audio proxy keeps talking to this local encoder.
+    if [[ "${ENABLE_VNC_AUDIO}" == "true" ]]; then
+        print_step_header "Enable audio stream"
+        sed -i 's|^autostart.*=.*$|autostart=true|' /etc/supervisor.d/vnc-audio.ini
+    else
+        print_step_header "Disable audio stream"
+        print_step_header "Disable audio websock"
+        sed -i 's|^autostart.*=.*$|autostart=false|' /etc/supervisor.d/vnc-audio.ini
+    fi
+}
+
 if ([ "${MODE}" != "s" ] && [ "${MODE}" != "secondary" ]); then
 
     if [ "${WEB_UI_MODE:-}" = "vnc" ]; then
         print_step_header "Enable VNC server"
         sed -i 's|^autostart.*=.*$|autostart=true|' /etc/supervisor.d/vnc.ini
-
-        # TODO: Remove this... Always enable VNC audio
-        if [[ "${ENABLE_VNC_AUDIO}" == "true" ]]; then
-            # Enable supervisord script
-            sed -i 's|^autostart.*=.*$|autostart=true|' /etc/supervisor.d/vnc-audio.ini
-        else
-            print_step_header "Disable audio stream"
-            print_step_header "Disable audio websock"
-            # Disable supervisord script
-            sed -i 's|^autostart.*=.*$|autostart=false|' /etc/supervisor.d/vnc-audio.ini
-        fi
+        configure_vnc_audio_stream
     else
         print_step_header "Disable VNC server"
         sed -i 's|^autostart.*=.*$|autostart=false|' /etc/supervisor.d/vnc.ini
         sed -i 's|^autostart.*=.*$|autostart=false|' /etc/supervisor.d/vnc-audio.ini
     fi
 else
-    print_step_header "VNC server not available when container is run in 'secondary' mode"
-    sed -i 's|^autostart.*=.*$|autostart=false|' /etc/supervisor.d/vnc.ini
-    sed -i 's|^autostart.*=.*$|autostart=false|' /etc/supervisor.d/vnc-audio.ini
+    print_step_header "Enable VNC server"
+    sed -i 's|^autostart.*=.*$|autostart=true|' /etc/supervisor.d/vnc.ini
+    # print_step_header "VNC server not available when container is run in 'secondary' mode"
+    # sed -i 's|^autostart.*=.*$|autostart=false|' /etc/supervisor.d/vnc.ini
+    configure_vnc_audio_stream
 fi
 
 echo -e "\e[34mDONE\e[0m"

--- a/overlay/etc/supervisor.d/avahi.ini
+++ b/overlay/etc/supervisor.d/avahi.ini
@@ -1,0 +1,15 @@
+
+[program:avahi]
+priority=15
+autostart=true
+autorestart=true
+user=root
+directory=/
+command=avahi-daemon --no-drop-root
+stopsignal=INT
+stdout_logfile=/var/log/supervisor/avahi.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=7
+stderr_logfile=/var/log/supervisor/avahi.err.log
+stderr_logfile_maxbytes=10MB
+stderr_logfile_backups=7

--- a/overlay/etc/supervisor.d/avahi.ini
+++ b/overlay/etc/supervisor.d/avahi.ini
@@ -1,11 +1,11 @@
 
 [program:avahi]
 priority=15
-autostart=true
+autostart=false
 autorestart=true
 user=root
 directory=/
-command=avahi-daemon --no-drop-root
+command=/usr/bin/start-avahi.sh
 stopsignal=INT
 stdout_logfile=/var/log/supervisor/avahi.log
 stdout_logfile_maxbytes=10MB

--- a/overlay/etc/supervisor.d/steam.ini
+++ b/overlay/etc/supervisor.d/steam.ini
@@ -10,7 +10,7 @@ autorestart=true
 startretries=50
 user=%(ENV_USER)s
 directory=/home/%(ENV_USER)s
-command=/usr/games/steam %(ENV_STEAM_ARGS)s
+command=/usr/bin/start-steam.sh %(ENV_STEAM_ARGS)s
 environment=HOME="/home/%(ENV_USER)s",USER="%(ENV_USER)s",DISPLAY="%(ENV_DISPLAY)s"
 stopsignal=INT
 stdout_logfile=/home/%(ENV_USER)s/.cache/log/steam.log

--- a/overlay/etc/supervisor.d/vnc.ini
+++ b/overlay/etc/supervisor.d/vnc.ini
@@ -20,7 +20,7 @@ autostart=false
 autorestart=true
 user=root
 command=/opt/frontend/utils/run.sh --web-port %(ENV_PORT_NOVNC_WEB)s --remote-host localhost --vnc-port %(ENV_PORT_VNC)s --audio-port %(ENV_PORT_AUDIO_STREAM)s
-environment=HOME="/home/%(ENV_USER)s",USER="%(ENV_USER)s",PORT_AUDIO_WEBSOCKET="%(PORT_AUDIO_WEBSOCKET)s",DOMAIN_AUDIO_WEBSOCKET="%(DOMAIN_AUDIO_WEBSOCKET)s"
+environment=HOME="/home/%(ENV_USER)s",USER="%(ENV_USER)s",PORT_AUDIO_WEBSOCKET="%(ENV_PORT_AUDIO_WEBSOCKET)s",DOMAIN_AUDIO_WEBSOCKET="%(ENV_DOMAIN_AUDIO_WEBSOCKET)s"
 stopsignal=INT
 stdout_logfile=/home/%(ENV_USER)s/.cache/log/novnc.log
 stdout_logfile_maxbytes=10MB

--- a/overlay/etc/supervisor.d/vnc.ini
+++ b/overlay/etc/supervisor.d/vnc.ini
@@ -20,7 +20,7 @@ autostart=false
 autorestart=true
 user=root
 command=/opt/frontend/utils/run.sh --web-port %(ENV_PORT_NOVNC_WEB)s --remote-host localhost --vnc-port %(ENV_PORT_VNC)s --audio-port %(ENV_PORT_AUDIO_STREAM)s
-environment=HOME="/home/%(ENV_USER)s",USER="%(ENV_USER)s"
+environment=HOME="/home/%(ENV_USER)s",USER="%(ENV_USER)s",PORT_AUDIO_WEBSOCKET="%(PORT_AUDIO_WEBSOCKET)s",DOMAIN_AUDIO_WEBSOCKET="%(DOMAIN_AUDIO_WEBSOCKET)s"
 stopsignal=INT
 stdout_logfile=/home/%(ENV_USER)s/.cache/log/novnc.log
 stdout_logfile_maxbytes=10MB

--- a/overlay/templates/sunshine/sunshine.conf
+++ b/overlay/templates/sunshine/sunshine.conf
@@ -288,3 +288,4 @@ channels = 2
 # flags = 012
 #
 # See: sunshine --help for all options under the header: flags
+

--- a/overlay/templates/xorg/xorg.dummy.conf
+++ b/overlay/templates/xorg/xorg.dummy.conf
@@ -17,7 +17,8 @@ Section "Screen"
     Device          "Configured Video Device"
     DefaultDepth    24
     SubSection      "Display"
-    Depth           24
-    Modes           "1920x1080" "1280x800" "1024x768" "1920x1080" "1600x900" "1440x900"
+        Virtual     1600 900
+        Depth           24
+        Modes           "1920x1080" "1280x800" "1024x768" "1920x1080" "1600x900" "1440x900"
     EndSubSection
 EndSection

--- a/overlay/templates/xorg/xorg.olares1.conf
+++ b/overlay/templates/xorg/xorg.olares1.conf
@@ -1,0 +1,42 @@
+Section "ServerLayout"
+    Identifier     "Default Layout"
+    Screen      0  "Default Screen"
+EndSection
+
+Section "Monitor"
+    Modeline "1920x1080R"  138.50  1920 1968 2000 2080  1080 1083 1088 1111 +hsync -vsync
+    Identifier     "Configured Monitor"
+    HorizSync       5.0 - 1000.0
+    VertRefresh     5.0 - 200.0
+    ModeLine       "1920x1080" 148.50 1920 2448 2492 2640 1080 1084 1089 1125 +hsync +vsync
+EndSection
+
+Section "Device"
+    Identifier     "Configured Video Device"
+    Driver         "nvidia"
+    Option         "ModeValidation" "NoMaxPClkCheck, NoEdidMaxPClkCheck, NoMaxSizeCheck, NoHorizSyncCheck, NoVertRefreshCheck, NoVirtualSizeCheck, NoTotalSizeCheck, NoDualLinkDVICheck, NoDisplayPortBandwidthCheck, AllowNon3DVisionModes, AllowNonHDMI3DModes, AllowNonEdidModes, NoEdidHDMI2Check, AllowDpInterlaced"
+    Option         "AllowEmptyInitialConfiguration"
+    Option         "PrimaryGPU" "yes"
+    Option         "AllowExternalGpus" "True"
+    BusID          "PCI:1:0:0"
+EndSection
+
+Section "Screen"
+    Identifier     "Default Screen"
+    Device         "Configured Video Device"
+    Monitor        "Configured Monitor"
+    DefaultDepth    24
+    Option         "ProbeAllGpus" "False"
+    Option         "BaseMosaic" "False"
+    Option         "AllowEmptyInitialConfiguration" "True"
+    Option         "ConnectedMonitor" "DFP"
+    SubSection     "Display"
+        Virtual     1920 1080
+        Depth       24
+        Modes       "1920x1080" "1280x800" "1024x768" "1920x1080" "1600x900" "1440x900"
+    EndSubSection
+EndSection
+
+Section "ServerFlags"
+    Option "AutoAddGPU" "false"
+EndSection

--- a/overlay/templates/xorg/xorg.olares1.conf
+++ b/overlay/templates/xorg/xorg.olares1.conf
@@ -18,7 +18,7 @@ Section "Device"
     Option         "AllowEmptyInitialConfiguration"
     Option         "PrimaryGPU" "yes"
     Option         "AllowExternalGpus" "True"
-    BusID          "PCI:1:0:0"
+    BusID          "PCI:2:0:0"
 EndSection
 
 Section "Screen"

--- a/overlay/templates/xorg/xorg.olares1.conf
+++ b/overlay/templates/xorg/xorg.olares1.conf
@@ -8,16 +8,22 @@ Section "Monitor"
     Identifier     "Configured Monitor"
     HorizSync       5.0 - 1000.0
     VertRefresh     5.0 - 200.0
-    ModeLine       "1920x1080" 148.50 1920 2448 2492 2640 1080 1084 1089 1125 +hsync +vsync
 EndSection
 
 Section "Device"
     Identifier     "Configured Video Device"
     Driver         "nvidia"
-    Option         "ModeValidation" "NoMaxPClkCheck, NoEdidMaxPClkCheck, NoMaxSizeCheck, NoHorizSyncCheck, NoVertRefreshCheck, NoVirtualSizeCheck, NoTotalSizeCheck, NoDualLinkDVICheck, NoDisplayPortBandwidthCheck, AllowNon3DVisionModes, AllowNonHDMI3DModes, AllowNonEdidModes, NoEdidHDMI2Check, AllowDpInterlaced"
+    # NoMaxPClkCheck is deliberately absent: it is the only guard left against
+    # programming a mode the head cannot physically scan out. Dropping it lets a
+    # client-requested mode wedge the display engine (Xid 16, no vblank, X spins
+    # at 100% CPU and never recovers without a reboot).
+    Option         "ModeValidation" "NoEdidMaxPClkCheck, NoMaxSizeCheck, NoHorizSyncCheck, NoVertRefreshCheck, NoVirtualSizeCheck, NoTotalSizeCheck, NoDisplayPortBandwidthCheck, AllowNonEdidModes, NoEdidHDMI2Check"
     Option         "AllowEmptyInitialConfiguration"
-    Option         "PrimaryGPU" "yes"
     Option         "AllowExternalGpus" "True"
+    # DFP-1 is an internal DisplayPort head (9520 MHz max pixel clock). The bare
+    # "DFP" string resolves to DFP-0, an internal TMDS head capped at 165 MHz,
+    # which cannot scan out anything above 1080p60.
+    Option         "ConnectedMonitor" "DFP-1"
     BusID          "PCI:2:0:0"
 EndSection
 
@@ -29,11 +35,11 @@ Section "Screen"
     Option         "ProbeAllGpus" "False"
     Option         "BaseMosaic" "False"
     Option         "AllowEmptyInitialConfiguration" "True"
-    Option         "ConnectedMonitor" "DFP"
+    Option         "ConnectedMonitor" "DFP-1"
     SubSection     "Display"
-        Virtual     1920 1080
+        Virtual     3840 2160
         Depth       24
-        Modes       "1920x1080" "1280x800" "1024x768" "1920x1080" "1600x900" "1440x900"
+        Modes       "1920x1080"
     EndSubSection
 EndSection
 

--- a/overlay/usr/bin/common-functions.sh
+++ b/overlay/usr/bin/common-functions.sh
@@ -102,3 +102,16 @@ wait_for_desktop_dbus_session() {
         fi
     done
 }
+
+wait_for_udevd() {
+    MAX=10
+    CT=0
+    while [ $(ps -ef|grep systemd-udevd |grep -v grep|wc -l) -eq 0 ]; do
+        sleep 1
+        CT=$(( CT + 1 ))
+        if [ "$CT" -ge "$MAX" ]; then
+            echo "FATAL: $0: Gave up waiting for systemd-udevd server to start"
+            exit 11
+        fi
+    done
+}

--- a/overlay/usr/bin/common-functions.sh
+++ b/overlay/usr/bin/common-functions.sh
@@ -116,8 +116,49 @@ wait_for_udevd() {
     done
 }
 
+# True when the underlay macvlan NIC exists. IP may still be missing.
+has_net1_device() {
+    [ -d /sys/class/net/net1 ]
+}
+
+# True when net1 has an IPv4 address (olaresd is not proxying mDNS).
+has_underlay_ip() {
+    [ -n "$(ifconfig net1 2>/dev/null | grep -oP 'inet (addr:)?\K[\d\.]+' | head -n1)" ]
+}
+
+# macvlan-init can lag the container entrypoint by a few seconds.
+wait_for_underlay_ip() {
+    local max="${1:-15}"
+    local ct=0
+    if ! has_net1_device; then
+        return 1
+    fi
+    while ! has_underlay_ip; do
+        sleep 1
+        ct=$((ct + 1))
+        if [ "${ct}" -ge "${max}" ]; then
+            return 1
+        fi
+    done
+    return 0
+}
+
+# Private system bus used only by avahi (never the host /run/dbus socket).
+export_avahi_dbus() {
+    export DBUS_SYSTEM_BUS_ADDRESS="unix:path=/run/avahi-bus/bus"
+}
+
 # Wait for avahi-daemon to start
 wait_for_avahi() {
+    if ! has_net1_device; then
+        echo "skip avahi-daemon: no net1, mDNS is proxied by olaresd"
+        return 0
+    fi
+    if ! wait_for_underlay_ip 15; then
+        echo "skip avahi-daemon: net1 has no IPv4, mDNS is proxied by olaresd"
+        return 0
+    fi
+    export_avahi_dbus
     MAX=10
     CT=0
     while ! pgrep -x avahi-daemon >/dev/null 2>&1; do

--- a/overlay/usr/bin/common-functions.sh
+++ b/overlay/usr/bin/common-functions.sh
@@ -115,3 +115,17 @@ wait_for_udevd() {
         fi
     done
 }
+
+# Wait for avahi-daemon to start
+wait_for_avahi() {
+    MAX=10
+    CT=0
+    while ! pgrep -x avahi-daemon >/dev/null 2>&1; do
+        sleep 1
+        CT=$(( CT + 1 ))
+        if [ "$CT" -ge "$MAX" ]; then
+            echo "FATAL: $0: Gave up waiting for avahi-daemon to start"
+            exit 11
+        fi
+    done
+}

--- a/overlay/usr/bin/install_protonup.sh
+++ b/overlay/usr/bin/install_protonup.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
-echo "**** Installing/upgrading ProtonUp-Qt via flatpak ****"
+echo "**** Installing/upgrading ProtonUp-Qt from local AppImage ****"
 
-# Install ProtonUp-Qt
-flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo 
-flatpak --user install --assumeyes --or-update net.davidotek.pupgui2
+PROTONUP_VERSION="2.8.2"
+APPIMAGE_PATH="/usr/local/src/ProtonUp-Qt-${PROTONUP_VERSION}-x86_64.AppImage"
 
-# Configure ProtonUp-Qt
-echo "Configure ProtonUp-Qt..."
-sed -i 's/^Categories=.*$/Categories=Utility;/' \
-    ${USER_HOME}/.local/share/flatpak/exports/share/applications/net.davidotek.pupgui2.desktop
+# Make AppImage executable
+chmod +x "${APPIMAGE_PATH}"
+
+# Create symbolic link in /usr/local/bin
+ln -sf "${APPIMAGE_PATH}" /usr/local/bin/protonup-qt
 
 echo "DONE"

--- a/overlay/usr/bin/install_steam_pkg.sh
+++ b/overlay/usr/bin/install_steam_pkg.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+echo "**** Installing/upgrading Steam package ****"
+
+mkdir -p ${USER_HOME}/.steam/debian-installation/package
+
+pkg=(
+steamui_websrc_all.zip.vz.deeae77fea80a3110c15d0e9a63c2a95ab6ab647_24679493
+resources_misc_all.zip.vz.e86a975545f3ab21a77373870cb311ef93934b8c_2224876
+public_all.zip.vz.b0ad1267ec973fc34840c92ebbf4b35b0c40cc17_23591292
+steamui_websrc_sounds_all.zip.vz.a2b25775b33d943e54c45d176558de379111ef5f_3220470
+bins_ubuntu12.zip.vz.f83baf36035930788f01ab03017d333af41dad5c_30138834
+bins_sdk_ubuntu12.zip.vz.c30c0a3a11027dd16cabaa3512e15615dd0d4dde_19880133
+bins_codecs_ubuntu12.zip.vz.16bd95e339abaabf87d7d50ed4822fc0d67b590d_8752315
+bins_misc_ubuntu12.zip.vz.72be98aad8e15e7b92bfccfe7c4268b720870b9c_18827909
+webkit_ubuntu12.zip.vz.57c0e0d3866ff0cdaa4af1f0fb2a0393a31a7906_79943183
+runtime_scout_ubuntu12.zip.2422dc5093c67022c86b17493e49f66124f182d0
+runtime_sniper_ubuntu12.zip.328e060d569aa12d70746dab1f74cd54196edf9c
+)
+
+for p in ${pkg[@]}; do
+    if [[ -f ${USER_HOME}/.steam/debian-installation/package/$p ]]; then
+        echo "Downloading [${p}] ... "
+        wget -O ${USER_HOME}/.steam/debian-installation/package/$p http://media.steampowered.com/client/$p
+    fi
+done
+
+echo "DONE"

--- a/overlay/usr/bin/install_steam_pkg.sh
+++ b/overlay/usr/bin/install_steam_pkg.sh
@@ -43,8 +43,10 @@ for p in ${pkg[@]}; do
 done
 
 echo "Install GE-Proton ... "
-mkdir -p ${USER_HOME}/.steam/debian-installation/compatibilitytools.d
-cd ${USER_HOME}/.steam/debian-installation/compatibilitytools.d
-tar zxvf /usr/local/src/GE-Proton9-15.tar.gz
+if [[ ! -f ${USER_HOME}/.steam/debian-installation/compatibilitytools.d/GE-Proton9-15 ]]; then
+    mkdir -p ${USER_HOME}/.steam/debian-installation/compatibilitytools.d
+    cd ${USER_HOME}/.steam/debian-installation/compatibilitytools.d
+    tar zxvf /usr/local/src/GE-Proton9-15.tar.gz
+if
 
 echo "DONE"

--- a/overlay/usr/bin/install_steam_pkg.sh
+++ b/overlay/usr/bin/install_steam_pkg.sh
@@ -19,9 +19,19 @@ runtime_sniper_ubuntu12.zip.328e060d569aa12d70746dab1f74cd54196edf9c
 )
 
 for p in ${pkg[@]}; do
-    if [[ -f ${USER_HOME}/.steam/debian-installation/package/$p ]]; then
+    if [[ ! -f ${USER_HOME}/.steam/debian-installation/package/$p ]]; then
         echo "Downloading [${p}] ... "
-        wget -O ${USER_HOME}/.steam/debian-installation/package/$p http://media.steampowered.com/client/$p
+        checksum=$(echo $p|awk -F'.' '{print $NF}'|awk -F'_' '{print $1}')
+        retry=10
+        while [[ retry -gt 0 ]]; do
+            wget -O ${USER_HOME}/.steam/debian-installation/package/$p http://media.steampowered.com/client/$p
+            sum=$(sha1sum ${USER_HOME}/.steam/debian-installation/package/$p|awk '{print $1}')
+            if [[ x"$sum" == x"$checksum" ]]; then
+                break
+            fi
+
+            ((retry--))
+        done
     fi
 done
 

--- a/overlay/usr/bin/install_steam_pkg.sh
+++ b/overlay/usr/bin/install_steam_pkg.sh
@@ -5,6 +5,13 @@ echo "**** Installing/upgrading Steam package ****"
 mkdir -p ${USER_HOME}/.steam/debian-installation/package
 
 pkg=(
+tenfoot_images_all.zip.vz.193cb8c4eb4446698ea2c0a9e8c4e6b6a623dac7_5572671
+resources_all.zip.vz.3d492fce87e5ccddbb855f26680b0c6798901010_2867227
+strings_all.zip.vz.2bee49ebaa1cf153bea903b50ecdaaeb6770168f_2006028
+steamui_websrc_movies_all.zip.4d2183b0476852dfb695b8d70192a0ccece8c7d0
+miles_ubuntu12.zip.vz.5093ef941e6e5195a60ab3259077694dec994016_295496
+sdl3_ubuntu12.zip.vz.efad8d8e33b4eefbefb0f04baad255ea3e064aae_6347963
+steam_ubuntu12.zip.vz.9a27820e0e317c8c302f9ceef6f43bc5e0f00108_2618473
 steamui_websrc_all.zip.vz.deeae77fea80a3110c15d0e9a63c2a95ab6ab647_24679493
 resources_misc_all.zip.vz.e86a975545f3ab21a77373870cb311ef93934b8c_2224876
 public_all.zip.vz.b0ad1267ec973fc34840c92ebbf4b35b0c40cc17_23591292
@@ -34,5 +41,10 @@ for p in ${pkg[@]}; do
         done
     fi
 done
+
+echo "Install GE-Proton ... "
+mkdir -p ${USER_HOME}/.steam/debian-installation/compatibilitytools.d
+cd ${USER_HOME}/.steam/debian-installation/compatibilitytools.d
+tar zxvf /usr/local/src/GE-Proton9-15.tar.gz
 
 echo "DONE"

--- a/overlay/usr/bin/install_steam_pkg.sh
+++ b/overlay/usr/bin/install_steam_pkg.sh
@@ -2,8 +2,6 @@
 
 echo "**** Installing/upgrading Steam package ****"
 
-mkdir -p ${USER_HOME}/.steam/debian-installation/package
-
 pkg=(
 tenfoot_images_all.zip.vz.193cb8c4eb4446698ea2c0a9e8c4e6b6a623dac7_5572671
 resources_all.zip.vz.3d492fce87e5ccddbb855f26680b0c6798901010_2867227
@@ -23,22 +21,58 @@ bins_misc_ubuntu12.zip.vz.72be98aad8e15e7b92bfccfe7c4268b720870b9c_18827909
 webkit_ubuntu12.zip.vz.57c0e0d3866ff0cdaa4af1f0fb2a0393a31a7906_79943183
 runtime_scout_ubuntu12.zip.2422dc5093c67022c86b17493e49f66124f182d0
 runtime_sniper_ubuntu12.zip.328e060d569aa12d70746dab1f74cd54196edf9c
+miles_ubuntu12.zip.vz.5093ef941e6e5195a60ab3259077694dec994016_295496
 )
+
+if [[ ${{PREINSTALL_STEAM_PACKAGE:-}} == "true" ]]; then
+    echo "Pre-installing Steam package ... "
+    for p in ${pkg[@]}; do
+        if [[ ! -f /usr/local/src/$p ]]; then
+            echo "Downloading [${p}] ... "
+            checksum=$(echo $p|awk -F'.' '{print $NF}'|awk -F'_' '{print $1}')
+            retry=10
+            while [[ retry -gt 0 ]]; do
+                wget -O /usr/local/src/$p http://media.steampowered.com/client/$p
+                sum=$(sha1sum /usr/local/src/$p|awk '{print $1}')
+                if [[ x"$sum" == x"$checksum" ]]; then
+                    break
+                fi
+
+                ((retry--))
+            done
+
+            if [[ ! -f /usr/local/src/$p ]]; then
+                echo "Failed to download [${p}] after multiple attempts, exiting."
+                exit 1
+            fi
+        fi
+    done
+
+    echo "Pre-install Steam package DONE"
+    exit 0
+fi
+
+mkdir -p ${USER_HOME}/.steam/debian-installation/package
 
 for p in ${pkg[@]}; do
     if [[ ! -f ${USER_HOME}/.steam/debian-installation/package/$p ]]; then
-        echo "Downloading [${p}] ... "
-        checksum=$(echo $p|awk -F'.' '{print $NF}'|awk -F'_' '{print $1}')
-        retry=10
-        while [[ retry -gt 0 ]]; do
-            wget -O ${USER_HOME}/.steam/debian-installation/package/$p http://media.steampowered.com/client/$p
-            sum=$(sha1sum ${USER_HOME}/.steam/debian-installation/package/$p|awk '{print $1}')
-            if [[ x"$sum" == x"$checksum" ]]; then
-                break
-            fi
+        if [[ -f /usr/local/src/$p ]]; then
+            echo "Copying pre-downloaded package [${p}] ... "
+            cp -v /usr/local/src/$p ${USER_HOME}/.steam/debian-installation/package/$p
+        else
+            echo "Downloading [${p}] ... "
+            checksum=$(echo $p|awk -F'.' '{print $NF}'|awk -F'_' '{print $1}')
+            retry=10
+            while [[ retry -gt 0 ]]; do
+                wget -O ${USER_HOME}/.steam/debian-installation/package/$p http://media.steampowered.com/client/$p
+                sum=$(sha1sum ${USER_HOME}/.steam/debian-installation/package/$p|awk '{print $1}')
+                if [[ x"$sum" == x"$checksum" ]]; then
+                    break
+                fi
 
-            ((retry--))
-        done
+                ((retry--))
+            done
+        fi
     fi
 done
 
@@ -47,6 +81,6 @@ if [[ ! -f ${USER_HOME}/.steam/debian-installation/compatibilitytools.d/GE-Proto
     mkdir -p ${USER_HOME}/.steam/debian-installation/compatibilitytools.d
     cd ${USER_HOME}/.steam/debian-installation/compatibilitytools.d
     tar zxvf /usr/local/src/GE-Proton9-15.tar.gz
-if
+fi
 
 echo "DONE"

--- a/overlay/usr/bin/install_steam_pkg.sh
+++ b/overlay/usr/bin/install_steam_pkg.sh
@@ -24,7 +24,7 @@ runtime_sniper_ubuntu12.zip.328e060d569aa12d70746dab1f74cd54196edf9c
 miles_ubuntu12.zip.vz.5093ef941e6e5195a60ab3259077694dec994016_295496
 )
 
-if [[ ${{PREINSTALL_STEAM_PACKAGE:-}} == "true" ]]; then
+if [[ ${PREINSTALL_STEAM_PACKAGE:-} == "true" ]]; then
     echo "Pre-installing Steam package ... "
     for p in ${pkg[@]}; do
         if [[ ! -f /usr/local/src/$p ]]; then

--- a/overlay/usr/bin/start-avahi.sh
+++ b/overlay/usr/bin/start-avahi.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+###
+# File: start-avahi.sh
+#
+# Two networking modes:
+#   - No macvlan / no net1: olaresd answers mDNS and rewrites Sunshine's
+#     advertised address to NODE_IP. Do not run avahi (it would fight olaresd).
+#   - macvlan net1: olaresd does not proxy. Avahi must answer on net1 and
+#     publish that underlay address.
+#
+# Avahi talks to a private system bus under /run/avahi-bus, never the host
+# socket at /run/dbus (host policy rejects org.freedesktop.Avahi, and we
+# must not register an Avahi name on the host bus).
+###
+set -e
+source /usr/bin/common-functions.sh
+
+AVAHI_BUS_DIR="/run/avahi-bus"
+AVAHI_BUS="${AVAHI_BUS_DIR}/bus"
+AVAHI_DBUS_CONF="/tmp/avahi-system-dbus.conf"
+dbus_pid=""
+
+_term() {
+    kill -TERM "${dbus_pid}" 2>/dev/null || true
+    pkill -TERM -x avahi-daemon 2>/dev/null || true
+}
+trap _term SIGTERM SIGINT
+
+if ! has_net1_device; then
+    echo "avahi: no net1 device; olaresd proxies mDNS, not starting"
+    exec sleep infinity
+fi
+
+if ! wait_for_underlay_ip 15; then
+    echo "avahi: net1 has no IPv4; olaresd still proxies mDNS, not starting"
+    exec sleep infinity
+fi
+
+UNDERLAY_IP="$(ifconfig net1 2>/dev/null | grep -oP 'inet (addr:)?\K[\d\.]+' | head -n1)"
+echo "avahi: macvlan mode, publishing on net1 (${UNDERLAY_IP:?})"
+
+# Restrict publishing to the underlay NIC.
+sed -i 's/^#\?allow-interfaces=.*/allow-interfaces=net1/' /etc/avahi/avahi-daemon.conf
+sed -i 's/^#\?enable-dbus=.*/enable-dbus=yes/' /etc/avahi/avahi-daemon.conf
+sed -i 's/^#\?publish-addresses=.*/publish-addresses=yes/' /etc/avahi/avahi-daemon.conf
+sed -i 's/^#\?publish-workstation=.*/publish-workstation=no/' /etc/avahi/avahi-daemon.conf
+
+mkdir -p "${AVAHI_BUS_DIR}" /run/avahi-daemon
+chmod 755 "${AVAHI_BUS_DIR}" /run/avahi-daemon
+rm -f "${AVAHI_BUS}"
+
+cat > "${AVAHI_DBUS_CONF}" <<'EOF'
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <type>system</type>
+  <keep_umask/>
+  <listen>unix:path=/run/avahi-bus/bus</listen>
+  <policy context="default">
+    <allow own="*"/>
+    <allow send_destination="*"/>
+    <allow eavesdrop="true"/>
+    <allow user="*"/>
+  </policy>
+</busconfig>
+EOF
+
+dbus-daemon --config-file="${AVAHI_DBUS_CONF}" --nofork --nopidfile &
+dbus_pid=$!
+
+for _ in $(seq 1 20); do
+    [ -S "${AVAHI_BUS}" ] && break
+    sleep 0.1
+done
+if [ ! -S "${AVAHI_BUS}" ]; then
+    echo "avahi: FATAL: private dbus socket ${AVAHI_BUS} was not created"
+    exit 1
+fi
+chmod 666 "${AVAHI_BUS}"
+
+export_avahi_dbus
+exec avahi-daemon --no-drop-root --no-chroot

--- a/overlay/usr/bin/start-desktop.sh
+++ b/overlay/usr/bin/start-desktop.sh
@@ -34,9 +34,9 @@ export XDG_DATA_HOME="${USER_HOME:?}/.local/share"
 # Wait for the X server to start
 wait_for_x
 # Install/Upgrade user apps
+# source /usr/bin/install_firefox.sh;
 if [[ ! -f /tmp/.desktop-apps-updated ]]; then
     xterm -geometry 200x50+0+0 -ls -e /bin/bash -c "
-        source /usr/bin/install_firefox.sh;
         source /usr/bin/install_protonup.sh;
         source /usr/bin/install_steam_pkg.sh;
         sleep 1;

--- a/overlay/usr/bin/start-desktop.sh
+++ b/overlay/usr/bin/start-desktop.sh
@@ -38,6 +38,7 @@ if [[ ! -f /tmp/.desktop-apps-updated ]]; then
     xterm -geometry 200x50+0+0 -ls -e /bin/bash -c "
         source /usr/bin/install_firefox.sh;
         source /usr/bin/install_protonup.sh;
+        source /usr/bin/install_steam_pkg.sh;
         sleep 1;
     "
     touch /tmp/.desktop-apps-updated

--- a/overlay/usr/bin/start-dumb-udev.sh
+++ b/overlay/usr/bin/start-dumb-udev.sh
@@ -16,11 +16,15 @@ _term() {
 }
 trap _term SIGTERM SIGINT
 
-
-# EXECUTE PROCESS:
-# Start dumb-udev
-dumb-udev &
-dumb_udev_pid=$!
+if [ "${ENABLE_SYSTEMD_UDEVD}" != "true" ]; then
+    # EXECUTE PROCESS:
+    # Start dumb-udev
+    dumb-udev &
+    dumb_udev_pid=$!
+else
+    /lib/systemd/systemd-udevd &
+    dumb_udev_pid=$!
+fi
 
 # WAIT FOR CHILD PROCESS:
 wait "$dumb_udev_pid"

--- a/overlay/usr/bin/start-pulseaudio.sh
+++ b/overlay/usr/bin/start-pulseaudio.sh
@@ -44,7 +44,7 @@ if [[ "${DEVICE_NAME}" = "Olares One" ]]; then
     # Set HDMI audio output
     pactl load-module module-alsa-sink device=plughw:0,3 sink_name=nvhdmi || { kill -TERM "$pulseaudio_pid" 2>/dev/null && exit 12; }
     amixer -c 0 sset 'IEC958' on
-    pactl unload-module module-alsa-sink
+    # pactl unload-module module-alsa-sink
 fi
 
 # WAIT FOR CHILD PROCESS:

--- a/overlay/usr/bin/start-pulseaudio.sh
+++ b/overlay/usr/bin/start-pulseaudio.sh
@@ -23,6 +23,12 @@ echo "PULSEAUDIO: Starting pulseaudio service"
 /usr/bin/pulseaudio --exit-idle-time=-1 &
 pulseaudio_pid=$!
 
+if [[ "${DEVICE_NAME}" = "Olares One" ]]; then
+    # Set HDMI audio output
+    pactl load-module module-alsa-sink device=plughw:0,3 sink_name=nvhdmi
+    amixer -c 0 sset 'IEC958' on
+    pactl unload-module module-alsa-sink
+fi
 
 # WAIT FOR CHILD PROCESS:
 wait "$pulseaudio_pid"

--- a/overlay/usr/bin/start-pulseaudio.sh
+++ b/overlay/usr/bin/start-pulseaudio.sh
@@ -23,9 +23,26 @@ echo "PULSEAUDIO: Starting pulseaudio service"
 /usr/bin/pulseaudio --exit-idle-time=-1 &
 pulseaudio_pid=$!
 
+
+wait_for_pulse() {
+    MAX=60 # About 30 seconds
+    CT=0
+    while ! pactl stat >/dev/null 2>&1; do
+        sleep 0.50s
+        CT=$(( CT + 1 ))
+        if [ "$CT" -ge "$MAX" ]; then
+            echo "FATAL: $0: Gave up waiting for pulse audio"
+            kill -TERM "$pulseaudio_pid" 2>/dev/null
+            exit 11
+        fi
+    done
+}
+
 if [[ "${DEVICE_NAME}" = "Olares One" ]]; then
+    echo "PULSEAUDIO: Setting Olares One HDMI audio output"
+    wait_for_pulse
     # Set HDMI audio output
-    pactl load-module module-alsa-sink device=plughw:0,3 sink_name=nvhdmi
+    pactl load-module module-alsa-sink device=plughw:0,3 sink_name=nvhdmi || { kill -TERM "$pulseaudio_pid" 2>/dev/null && exit 12; }
     amixer -c 0 sset 'IEC958' on
     pactl unload-module module-alsa-sink
 fi

--- a/overlay/usr/bin/start-pulseaudio.sh
+++ b/overlay/usr/bin/start-pulseaudio.sh
@@ -16,6 +16,10 @@ _term() {
 }
 trap _term SIGTERM SIGINT
 
+# k8s sets PULSE_SERVER=unix:/tmp/pulse/pulse-socket, but the daemon listens on
+# $XDG_RUNTIME_DIR/pulse/native until we explicitly expose that extra socket.
+# Using the env var here makes pactl fail, then this script kills PulseAudio.
+unset PULSE_SERVER
 
 # EXECUTE PROCESS:
 echo "PULSEAUDIO: Starting pulseaudio service"
@@ -38,13 +42,29 @@ wait_for_pulse() {
     done
 }
 
+wait_for_pulse
+
+# Expose the socket path that Steam/container env expects (PULSE_SERVER).
+if [ -n "${PULSE_SOCKET_DIR:-}" ]; then
+    mkdir -p "${PULSE_SOCKET_DIR}"
+    chmod 777 "${PULSE_SOCKET_DIR}"
+    if [ ! -S "${PULSE_SOCKET_DIR}/pulse-socket" ]; then
+        echo "PULSEAUDIO: Creating ${PULSE_SOCKET_DIR}/pulse-socket"
+        pactl load-module module-native-protocol-unix \
+            socket="${PULSE_SOCKET_DIR}/pulse-socket" auth-anonymous=1 \
+            || echo "PULSEAUDIO: WARNING: failed to create ${PULSE_SOCKET_DIR}/pulse-socket"
+    fi
+fi
+
 if [[ "${DEVICE_NAME}" = "Olares One" ]]; then
     echo "PULSEAUDIO: Setting Olares One HDMI audio output"
-    wait_for_pulse
     # Set HDMI audio output
-    pactl load-module module-alsa-sink device=plughw:0,3 sink_name=nvhdmi || { kill -TERM "$pulseaudio_pid" 2>/dev/null && exit 12; }
-    amixer -c 0 sset 'IEC958' on
-    # pactl unload-module module-alsa-sink
+    if pactl load-module module-alsa-sink device=plughw:0,3 sink_name=nvhdmi; then
+        pactl set-default-sink nvhdmi || true
+        amixer -c 0 sset 'IEC958' on || true
+    else
+        echo "PULSEAUDIO: WARNING: failed to load HDMI sink plughw:0,3"
+    fi
 fi
 
 # WAIT FOR CHILD PROCESS:

--- a/overlay/usr/bin/start-steam.sh
+++ b/overlay/usr/bin/start-steam.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+###
+# File: start-steam.sh
+# Project: bin
+# Drop stale Chromium singleton files before launching Steam.
+# htmlcache lives on the persistent home volume; after a pod recreate the
+# SingletonLock still names the previous hostname, and steamwebhelper then
+# refuses the profile ("in use ... on another computer").
+###
+set -e
+
+htmlcache="${HOME}/.steam/steam/config/htmlcache"
+if [ -d "${htmlcache}" ]; then
+    echo "STEAM: clearing stale CEF singleton files in ${htmlcache}"
+    rm -f \
+        "${htmlcache}/SingletonLock" \
+        "${htmlcache}/SingletonCookie" \
+        "${htmlcache}/SingletonSocket"
+fi
+
+exec /usr/games/steam "$@"

--- a/overlay/usr/bin/start-sunshine.sh
+++ b/overlay/usr/bin/start-sunshine.sh
@@ -38,7 +38,10 @@ trap _term SIGTERM SIGINT
 # Install default configurations
 mkdir -p "${USER_HOME:?}/.config/sunshine"
 # FIXME:
-cat /dev/null > ${USER_HOME:?}/.config/sunshine/so.preload && mount --bind ${USER_HOME:?}/.config/sunshine/so.preload /etc/ld.so.preload
+if [ -f /etc/ld.so.preload ]; then
+    cat /dev/null > ${USER_HOME:?}/.config/sunshine/so.preload && mount --bind ${USER_HOME:?}/.config/sunshine/so.preload /etc/ld.so.preload
+fi
+
 if [ ! -f "${USER_HOME:?}/.config/sunshine/sunshine.conf" ]; then
     cp -vf /templates/sunshine/sunshine.conf "${USER_HOME:?}/.config/sunshine/sunshine.conf"
 fi

--- a/overlay/usr/bin/start-sunshine.sh
+++ b/overlay/usr/bin/start-sunshine.sh
@@ -37,6 +37,8 @@ trap _term SIGTERM SIGINT
 # CONFIGURE:
 # Install default configurations
 mkdir -p "${USER_HOME:?}/.config/sunshine"
+# FIXME:
+cat /dev/null > ${USER_HOME:?}/.config/sunshine/so.preload && mount --bind ${USER_HOME:?}/.config/sunshine/so.preload /etc/ld.so.preload
 if [ ! -f "${USER_HOME:?}/.config/sunshine/sunshine.conf" ]; then
     cp -vf /templates/sunshine/sunshine.conf "${USER_HOME:?}/.config/sunshine/sunshine.conf"
 fi

--- a/overlay/usr/bin/start-sunshine.sh
+++ b/overlay/usr/bin/start-sunshine.sh
@@ -67,6 +67,11 @@ export_desktop_dbus_session
 # Wait for the desktop to start
 wait_for_desktop
 
+if [ "${ENABLE_SYSTEMD_UDEVD}" == "true" ]; then
+    echo "wait for systemd-udevd"
+    wait_for_udevd
+fi
+
 # Start the sunshine server
 /usr/bin/dumb-init /usr/bin/sunshine "${USER_HOME:?}/.config/sunshine/sunshine.conf" &
 sunshine_pid=$!

--- a/overlay/usr/bin/start-sunshine.sh
+++ b/overlay/usr/bin/start-sunshine.sh
@@ -44,6 +44,7 @@ fi
 
 if [ ! -f "${USER_HOME:?}/.config/sunshine/sunshine.conf" ]; then
     cp -vf /templates/sunshine/sunshine.conf "${USER_HOME:?}/.config/sunshine/sunshine.conf"
+    echo "external_ip = ${NODE_IP}" >> "${USER_HOME:?}/.config/sunshine/sunshine.conf"
 fi
 if [ ! -f "${USER_HOME:?}/.config/sunshine/apps.json" ]; then
     cp -vf /templates/sunshine/apps.json "${USER_HOME:?}/.config/sunshine/apps.json"

--- a/overlay/usr/bin/start-sunshine.sh
+++ b/overlay/usr/bin/start-sunshine.sh
@@ -10,6 +10,7 @@
 ###
 set -e
 source /usr/bin/common-functions.sh
+unset LD_PRELOAD   # FIXME:
 
 # CATCH TERM SIGNAL:
 _term() {

--- a/overlay/usr/bin/start-sunshine.sh
+++ b/overlay/usr/bin/start-sunshine.sh
@@ -45,6 +45,8 @@ fi
 if [ ! -f "${USER_HOME:?}/.config/sunshine/sunshine.conf" ]; then
     cp -vf /templates/sunshine/sunshine.conf "${USER_HOME:?}/.config/sunshine/sunshine.conf"
     echo "external_ip = ${NODE_IP}" >> "${USER_HOME:?}/.config/sunshine/sunshine.conf"
+else
+    sed -i "s/external_ip = .*/external_ip = ${NODE_IP}/" "${USER_HOME:?}/.config/sunshine/sunshine.conf"
 fi
 if [ ! -f "${USER_HOME:?}/.config/sunshine/apps.json" ]; then
     cp -vf /templates/sunshine/apps.json "${USER_HOME:?}/.config/sunshine/apps.json"

--- a/overlay/usr/bin/start-sunshine.sh
+++ b/overlay/usr/bin/start-sunshine.sh
@@ -85,6 +85,10 @@ export_desktop_dbus_session
 # Wait for the desktop to start
 wait_for_desktop
 
+# Wait for avahi-daemon (mDNS) to start
+echo "wait for avahi-daemon"
+wait_for_avahi
+
 if [ "${ENABLE_SYSTEMD_UDEVD}" == "true" ]; then
     echo "wait for systemd-udevd"
     wait_for_udevd

--- a/overlay/usr/bin/start-sunshine.sh
+++ b/overlay/usr/bin/start-sunshine.sh
@@ -43,7 +43,7 @@ if [ -f /etc/ld.so.preload ]; then
 fi
 
 EXTERNAL_IP="${NODE_IP:?}"
-UNDERLAY_IP=$(ifconfig net1 | grep -oP 'inet (addr:)?\K[\d\.]+' | head -n1)
+UNDERLAY_IP=$(ifconfig net1 2>/dev/null | grep -oP 'inet (addr:)?\K[\d\.]+' | head -n1)
 if [ "X${UNDERLAY_IP}" != "X" ]; then
     EXTERNAL_IP="${UNDERLAY_IP:?}"
 fi
@@ -74,18 +74,20 @@ if [ -f "${USER_HOME:?}/.config/autostart/Sunshine.desktop" ]; then
 fi
 
 
-# EXECUTE PROCESS:
-# Wait for the X server to start
-wait_for_x
+if ([ "${MODE}" != "s" ] && [ "${MODE}" != "secondary" ]); then
+    # EXECUTE PROCESS:
+    # Wait for the X server to start
+    wait_for_x
 
-# Start a session bus instance of dbus-daemon
-wait_for_desktop_dbus_session
-export_desktop_dbus_session
+    # Start a session bus instance of dbus-daemon
+    wait_for_desktop_dbus_session
+    export_desktop_dbus_session
 
-# Wait for the desktop to start
-wait_for_desktop
-
-# Wait for avahi-daemon (mDNS) to start
+    # Wait for the desktop to start
+    wait_for_desktop
+fi
+# Wait for avahi-daemon only when macvlan net1 is the mDNS path.
+# Without net1, olaresd proxies _nvstream._tcp and Sunshine advertises NODE_IP.
 echo "wait for avahi-daemon"
 wait_for_avahi
 

--- a/overlay/usr/bin/start-sunshine.sh
+++ b/overlay/usr/bin/start-sunshine.sh
@@ -39,7 +39,7 @@ trap _term SIGTERM SIGINT
 mkdir -p "${USER_HOME:?}/.config/sunshine"
 # FIXME:
 if [ -f /etc/ld.so.preload ]; then
-    cat /dev/null > ${USER_HOME:?}/.config/sunshine/so.preload && mount --bind ${USER_HOME:?}/.config/sunshine/so.preload /etc/ld.so.preload
+    cat /dev/null > ${USER_HOME:?}/.config/sunshine/so.preload && sudo mount --bind ${USER_HOME:?}/.config/sunshine/so.preload /etc/ld.so.preload
 fi
 
 EXTERNAL_IP="${NODE_IP:?}"

--- a/overlay/usr/bin/start-sunshine.sh
+++ b/overlay/usr/bin/start-sunshine.sh
@@ -42,11 +42,17 @@ if [ -f /etc/ld.so.preload ]; then
     cat /dev/null > ${USER_HOME:?}/.config/sunshine/so.preload && mount --bind ${USER_HOME:?}/.config/sunshine/so.preload /etc/ld.so.preload
 fi
 
+EXTERNAL_IP="${NODE_IP:?}"
+UNDERLAY_IP=$(ifconfig net1 | grep -oP 'inet (addr:)?\K[\d\.]+' | head -n1)
+if [ "X${UNDERLAY_IP}" != "X" ]; then
+    EXTERNAL_IP="${UNDERLAY_IP:?}"
+fi
+
 if [ ! -f "${USER_HOME:?}/.config/sunshine/sunshine.conf" ]; then
     cp -vf /templates/sunshine/sunshine.conf "${USER_HOME:?}/.config/sunshine/sunshine.conf"
-    echo "external_ip = ${NODE_IP}" >> "${USER_HOME:?}/.config/sunshine/sunshine.conf"
+    echo "external_ip = ${EXTERNAL_IP}" >> "${USER_HOME:?}/.config/sunshine/sunshine.conf"
 else
-    sed -i "s/external_ip = .*/external_ip = ${NODE_IP}/" "${USER_HOME:?}/.config/sunshine/sunshine.conf"
+    sed -i "s/external_ip = .*/external_ip = ${EXTERNAL_IP}/" "${USER_HOME:?}/.config/sunshine/sunshine.conf"
 fi
 if [ ! -f "${USER_HOME:?}/.config/sunshine/apps.json" ]; then
     cp -vf /templates/sunshine/apps.json "${USER_HOME:?}/.config/sunshine/apps.json"

--- a/overlay/usr/bin/start-udev.sh
+++ b/overlay/usr/bin/start-udev.sh
@@ -21,7 +21,7 @@ trap _term SIGTERM SIGINT
 if command -v udevd &>/dev/null; then
     unshare --net udevd --daemon &>/dev/null
 else
-    /lib/systemd/systemd-udevd --daemon 
+    /lib/systemd/systemd-udevd --daemon &>/dev/null
 fi
 # Monitor kernel uevents
 udevadm monitor &

--- a/overlay/usr/bin/start-udev.sh
+++ b/overlay/usr/bin/start-udev.sh
@@ -21,7 +21,7 @@ trap _term SIGTERM SIGINT
 if command -v udevd &>/dev/null; then
     unshare --net udevd --daemon &>/dev/null
 else
-    /lib/systemd/systemd-udevd --daemon &>/dev/null
+    unshare --net /lib/systemd/systemd-udevd --daemon &>/dev/null
 fi
 # Monitor kernel uevents
 udevadm monitor &

--- a/overlay/usr/bin/start-udev.sh
+++ b/overlay/usr/bin/start-udev.sh
@@ -21,7 +21,7 @@ trap _term SIGTERM SIGINT
 if command -v udevd &>/dev/null; then
     unshare --net udevd --daemon &>/dev/null
 else
-    unshare --net /lib/systemd/systemd-udevd --daemon &>/dev/null
+    /lib/systemd/systemd-udevd --daemon 
 fi
 # Monitor kernel uevents
 udevadm monitor &

--- a/overlay/usr/bin/start-x11vnc.sh
+++ b/overlay/usr/bin/start-x11vnc.sh
@@ -22,7 +22,12 @@ trap _term SIGTERM SIGINT
 # Wait for the X server to start
 wait_for_x
 # Start the x11vnc server
-/usr/bin/x11vnc -display ${DISPLAY} -rfbport ${PORT_VNC} -shared -forever&
+EXTRA_ARGS="${VNC_EXTRA_ARGS:-}"
+if ([ "${MODE}" == "s" ] || [ "${MODE}" == "secondary" ]); then
+    EXTRA_ARGS="${EXTRA_ARGS} -auth /home/default/.Xauthority -noshm "
+fi
+
+/usr/bin/x11vnc -display ${DISPLAY} -rfbport ${PORT_VNC} -shared -forever ${EXTRA_ARGS} &
 x11vnc_pid=$!
 
 


### PR DESCRIPTION
## Problem

On an Olares One host (RTX 5090 Laptop, no physical monitor attached), connecting a Moonlight client at 4K120 permanently wedged the GPU's display engine. Symptoms on the host:

```
NVRM: Xid (PCI:0000:02:00): 16, pid=41466, name=Xorg, Head 00000003
NVRM: krcWatchdogCallbackVblankRecovery_IMPL: RM has detected that 7 Seconds
      without a Vblank Counter Update on head:D0
nvidia-modeset: ERROR: GPU:0: Idling display engine timed out
```

and inside the container:

```
(WW) NVIDIA: Wait for channel idle timed out.
```

Xorg spun at 100% CPU and stopped answering new clients (`xrandr` hung indefinitely), so x11vnc and Sunshine both lost their frame source and the VNC session and stream broke together. HAMi then reported the GPU as unhealthy, and other pods failed to schedule with `no healthy devices present; cannot allocate unhealthy devices nvidia.com/gpu`. The GPU did not recover across an X restart — only a host reboot cleared it.

## Root cause

Three settings combined:

1. `xorg.olares1.conf` pinned the fake monitor with `Option "ConnectedMonitor" "DFP"`. The bare `DFP` string resolves to **DFP-0**, which on this GPU is an *internal TMDS* head with a **165 MHz** maximum pixel clock. The DisplayPort heads (DFP-1/3/5) allow **9520 MHz**, but were never selected.
2. The same file disabled every pixel clock guard via `NoMaxPClkCheck` and `NoEdidMaxPClkCheck`, so an unreachable mode was accepted instead of rejected.
3. On connect, `sunshine-run` builds a modeline from the client's request. `cvt 3840 2160 120` yields a **1498.25 MHz** pixel clock — roughly 9x the DFP-0 limit.

X programmed that mode onto the TMDS head:

```
[   321.372] (II) NVIDIA(0): Setting mode "HDMI-0: 3840x2160_120.00 @3840x2160 +0+0"
```

The head stopped producing vblanks and could no longer be idled, which is exactly what the kernel and Xorg messages above describe. `Virtual` was also only 1920x1080, so the 4K mode was additionally panned/clamped.

## Fix

- Point `ConnectedMonitor` at `DFP-1`, an internal DisplayPort head with 9520 MHz of headroom, so 4K120 is comfortably in range.
- Keep `NoMaxPClkCheck` enabled in both the Olares One template and the generated config, so a mode beyond the head's physical limit is rejected instead of programmed. This is the guard that turns a hardware hang into a harmless failure.
- Raise `Virtual` to 3840x2160 so 4K is a real target rather than being clamped.
- Drop `AllowDpInterlaced` (the driver logs `Unrecognized ModeValidation token`) and `PrimaryGPU` (logged as `Option "PrimaryGPU" is not used`).

`sunshine-run` needs no change: it already falls back to a validated `WxH --refresh` mode when `xrandr` refuses the custom one, and runs under `set +e`, so a rejected mode now degrades the stream instead of taking down the GPU.

## Test plan

Verified on the affected host (RTX 5090 Laptop, driver 595.84, no monitor attached), applying the exact file from this branch and restarting the container stack.

- [x] Xorg starts and parses the config: `Using ConnectedMonitor string "DFP-1"`, `Virtual screen size configured to be 3840 x 2160`, `Setting mode "DFP-1:1920x1080"`
- [x] `xrandr` reports `DP-0 connected` with modes up to 7680x4320, and responds instantly (it hung before)
- [x] Replaying the exact failing operation (`cvt 3840 2160 120` -> `xrandr --newmode/--addmode/--output`) now succeeds; `/proc/driver/nvidia-modeset/heads` shows `head 3: DP-0, protocol DP, 3840 x 2160 @ 119.6669 Hz`
- [x] 45s soak after the 4K120 modeset: **zero** `Vblank Counter`, `Idling display engine` or `Xid` entries in dmesg
- [x] Xorg at ~3% CPU (was pinned at 100%), X responsive
- [x] Sunshine initialises: `Found [1] outputs`, `XrandR: available`, `Screencasting with NvFBC`, `hevc_nvenc` encoder created; VNC (32036), noVNC (8083) and Sunshine (47989/47990) all listening

Not covered: hosts where `DEVICE_NAME` is not `Olares One` were only reasoned about, not re-tested. They take the generic path, which defaults to `--use-display-device=None` and therefore never lights up a head; the `NoMaxPClkCheck` change only matters there when `DISPLAY_VIDEO_PORT` is set.

Made with [Cursor](https://cursor.com)